### PR TITLE
Remove dependency on private vcpkg registry

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,15 +7,9 @@
   "registries": [
     {
       "kind": "git",
-      "repository": "git@github.com:ccpgames/carbon-vcpkg-registry.git",
-      "baseline": "10267e790a5504d5e783f835f7fc1395412579bb",
-      "packages": ["carbon-*", "greenlet", "tracy"]
-    },
-    {
-      "kind": "git",
       "repository": "git@github.com:carbonengine/vcpkg-registry.git",
-      "baseline": "d032ec0e827da97a160d3c1ca732544091f026e8",
-      "packages": ["python3", "ccp-debug-info"]
+      "baseline": "d431d05377ae8d620c644c49c3f4d1bd974cee18",
+      "packages": ["python3", "ccp-debug-info", "tracy"]
     }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "python3",
-      "version>=": "3.12.9",
+      "version>=": "3.12.9#1",
       "host": true
     }
   ]


### PR DESCRIPTION
- Depend on tracy through our carbonengine vcpkg registry.
- Upgrade to latest version of python port (for consistency across our components)
