### PR TITLE
Add presets for compilation with v145 toolchain on windows

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,18 +40,10 @@
       "hidden": true
     },
     {
-      "name": "x64-windows-145",
-      "inherits": "windows",
-      "cacheVariables": {
-        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-windows-145-carbon.cmake"
-      },
-      "hidden": true
-    },
-    {
       "name": "x64-windows",
       "inherits": "windows",
       "cacheVariables": {
-        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-windows-carbon.cmake"
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-windows-145-carbon.cmake"
       },
       "hidden": true
     },
@@ -74,7 +66,7 @@
       "hidden": true
     },
     {
-      "name": "x64-windows-145-internal",
+      "name": "x64-windows-internal",
       "inherits": "x64-windows-145",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Internal",
@@ -83,7 +75,7 @@
       }
     },
     {
-      "name": "x64-windows-145-release",
+      "name": "x64-windows-release",
       "inherits": "x64-windows-145",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
@@ -92,7 +84,7 @@
       }
     },
     {
-      "name": "x64-windows-145-debug",
+      "name": "x64-windows-debug",
       "inherits": "x64-windows-145",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -101,48 +93,12 @@
       }
     },
     {
-      "name": "x64-windows-145-trinitydev",
+      "name": "x64-windows-trinitydev",
       "inherits": "x64-windows-145",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "TrinityDev",
         "VCPKG_TARGET_TRIPLET": "x64-windows-145-trinitydev",
         "VCPKG_HOST_TRIPLET": "x64-windows-145-trinitydev"
-      }
-    },
-    {
-      "name": "x64-windows-internal",
-      "inherits": "x64-windows",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Internal",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-internal",
-        "VCPKG_HOST_TRIPLET": "x64-windows-internal"
-      }
-    },
-    {
-      "name": "x64-windows-release",
-      "inherits": "x64-windows",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-release",
-        "VCPKG_HOST_TRIPLET": "x64-windows-release"
-      }
-    },
-    {
-      "name": "x64-windows-debug",
-      "inherits": "x64-windows",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-debug",
-        "VCPKG_HOST_TRIPLET": "x64-windows-debug"
-      }
-    },
-    {
-      "name": "x64-windows-trinitydev",
-      "inherits": "x64-windows",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "TrinityDev",
-        "VCPKG_TARGET_TRIPLET": "x64-windows-trinitydev",
-        "VCPKG_HOST_TRIPLET": "x64-windows-trinitydev"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "x64-windows-internal",
-      "inherits": "x64-windows-145",
+      "inherits": "x64-windows",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Internal",
         "VCPKG_TARGET_TRIPLET": "x64-windows-145-internal",
@@ -76,7 +76,7 @@
     },
     {
       "name": "x64-windows-release",
-      "inherits": "x64-windows-145",
+      "inherits": "x64-windows",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release",
         "VCPKG_TARGET_TRIPLET": "x64-windows-145-release",
@@ -85,7 +85,7 @@
     },
     {
       "name": "x64-windows-debug",
-      "inherits": "x64-windows-145",
+      "inherits": "x64-windows",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "VCPKG_TARGET_TRIPLET": "x64-windows-145-debug",
@@ -94,7 +94,7 @@
     },
     {
       "name": "x64-windows-trinitydev",
-      "inherits": "x64-windows-145",
+      "inherits": "x64-windows",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "TrinityDev",
         "VCPKG_TARGET_TRIPLET": "x64-windows-145-trinitydev",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,6 +40,14 @@
       "hidden": true
     },
     {
+      "name": "x64-windows-145",
+      "inherits": "windows",
+      "cacheVariables": {
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-windows-145-carbon.cmake"
+      },
+      "hidden": true
+    },
+    {
       "name": "x64-windows",
       "inherits": "windows",
       "cacheVariables": {
@@ -64,6 +72,42 @@
         "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-osx-carbon.cmake"
       },
       "hidden": true
+    },
+    {
+      "name": "x64-windows-145-internal",
+      "inherits": "x64-windows-145",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Internal",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-145-internal",
+        "VCPKG_HOST_TRIPLET": "x64-windows-145-internal"
+      }
+    },
+    {
+      "name": "x64-windows-145-release",
+      "inherits": "x64-windows-145",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-145-release",
+        "VCPKG_HOST_TRIPLET": "x64-windows-145-release"
+      }
+    },
+    {
+      "name": "x64-windows-145-debug",
+      "inherits": "x64-windows-145",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-145-debug",
+        "VCPKG_HOST_TRIPLET": "x64-windows-145-debug"
+      }
+    },
+    {
+      "name": "x64-windows-145-trinitydev",
+      "inherits": "x64-windows-145",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "TrinityDev",
+        "VCPKG_TARGET_TRIPLET": "x64-windows-145-trinitydev",
+        "VCPKG_HOST_TRIPLET": "x64-windows-145-trinitydev"
+      }
     },
     {
       "name": "x64-windows-internal",


### PR DESCRIPTION
- Add presets to compile core with v145 of the MSVC toolchain. 
- Upgrade carbonengine/vcpkg-registry submodule to get new triplet & toolchain files