### PR TITLE
fix(fileutils): prevent stack buffer overflow in AbsPath

### DIFF
--- a/CcpFileUtils.cpp
+++ b/CcpFileUtils.cpp
@@ -217,6 +217,7 @@ bool CcpRenameFile( const std::wstring& src, const std::wstring& dst )
 #include <dirent.h>
 #include <unistd.h>
 #include <errno.h>
+#include <cstdio>
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
@@ -357,7 +358,7 @@ std::wstring CcpExecutablePath()
 namespace
 {
 
-void AbsPath( const char* path, char* realPath )
+void AbsPath( const char* path, char* realPath, size_t realPathSize )
 {
 	char src[PATH_MAX];
 	if( path[0] != '/' )
@@ -366,20 +367,26 @@ void AbsPath( const char* path, char* realPath )
 		// working directory
 		if( !getcwd( src, sizeof( src ) ) )
 		{
-			strcpy( realPath, path );
+			strncpy_s( realPath, realPathSize, path, _TRUNCATE );
 			return;
 		}
 
-		auto len = strlen( src );
-		if( len > 0 && path[0] != 0 && src[len - 1] != '/' )
+		size_t len = strlen( src );
+		const char* separator = ( len > 0 && path[0] != 0 && src[len - 1] != '/' ) ? "/" : "";
+		int written = snprintf( src + len, sizeof( src ) - len, "%s%s", separator, path );
+		if( written < 0 || static_cast<size_t>( written ) >= sizeof( src ) - len )
 		{
-			src[len] = '/';
-			src[len + 1] = 0;
+			realPath[0] = 0;
+			return;
 		}
-		strcat( src, path );
 	}
 	else
 	{
+		if( strlen( path ) >= sizeof( src ) )
+		{
+			realPath[0] = 0;
+			return;
+		}
 		strcpy( src, path );
 	}
 
@@ -432,6 +439,12 @@ void AbsPath( const char* path, char* realPath )
 		++end;
 	}
 
+	if( strlen( src ) + 1 > realPathSize )
+	{
+		realPath[0] = 0;
+		return;
+	}
+
 	// Put initial slashes back in
 	end = realPath;
 	for( size_t i = 0; i < initialSlashes; ++i )
@@ -463,10 +476,8 @@ std::wstring CcpGetAbsolutePath( const std::wstring& name )
 	{
 		return L"";
 	}
-	auto nameA = CW2A( name.c_str() );
 	char buffer[PATH_MAX];
-	strcpy_s( buffer, nameA );
-	AbsPath( CW2A( name.c_str() ), buffer );
+	AbsPath( CW2A( name.c_str() ), buffer, sizeof( buffer ) );
     std::wstring absName = std::wstring( CA2W( buffer ) );
     if( CcpIsPathDirectory( absName.c_str() ) && !absName.empty() && absName[absName.length() - 1] != L'/' )
     {

--- a/tests/CcpFileUtils.cpp
+++ b/tests/CcpFileUtils.cpp
@@ -126,3 +126,21 @@ TEST( CcpFileUtils, CcpGetAbsolutePathResolvesToNewFile )
 	unlink( tempFileName );
 #endif
 }
+
+#if !_WIN32
+
+TEST( CcpFileUtils, CcpGetAbsolutePathHandlesOverlongRelativePathSafely )
+{
+	std::wstring huge( 64 * 1024, L'a' );
+	auto path = CcpGetAbsolutePath( huge );
+	EXPECT_TRUE( path.empty() );
+}
+
+TEST( CcpFileUtils, CcpGetAbsolutePathHandlesOverlongAbsolutePathSafely )
+{
+	std::wstring huge = ROOT_PATH + std::wstring( 64 * 1024, L'a' );
+	auto path = CcpGetAbsolutePath( huge );
+	EXPECT_TRUE( path.empty() );
+}
+
+#endif


### PR DESCRIPTION
## Problem

`AbsPath` (POSIX path, used by `CcpGetAbsolutePath`) wrote into `char[PATH_MAX]` buffers with no bounds checking.
`getcwd(src, …)` followed by `strcat(src, path)` overflows the stack when `cwd + path` exceeds `PATH_MAX` (1024 on
macOS); `src[len] = '/'; src[len+1] = 0;` writes out of bounds when `len == PATH_MAX-1`; and `strcpy(src, path)`
(absolute path) plus `strcpy(realPath, path)` (on `getcwd` failure) are unbounded too. This is reachable on macOS (a
primary CI target) via `CcpGetAbsolutePath`, so it is a high-severity stack overflow driven entirely by path length.

## Fix

`AbsPath` now receives the output buffer size (`size_t realPathSize`) — there is a single internal caller. `src` is
built with a bounded `snprintf` and the function returns an empty string when the combined path does not fit. The
`getcwd` failure path uses `strncpy_s(…, _TRUNCATE)` instead of `strcpy`, and there is an explicit guard before
writing into `realPath`. `CcpGetAbsolutePath` drops a dead line (a `strcpy_s` that was immediately overwritten) and
its unused variable, and now passes `sizeof(buffer)`. Added `#include <cstdio>` in the POSIX block. Contract: when a
path is too long to fit, the function returns an empty string instead of overflowing.

## Tests

Added two regression tests in `tests/CcpFileUtils.cpp` (GoogleTest, `#if !_WIN32`):
`CcpGetAbsolutePathHandlesOverlongRelativePathSafely` and `CcpGetAbsolutePathHandlesOverlongAbsolutePathSafely`, both
using 64 KB paths and expecting an empty result with no crash. Existing path-resolution tests are unaffected. Reviewed
 manually; not compiled locally as the vcpkg toolchain is unavailable in this environment.

## Scope

POSIX branch only — the Windows path uses `GetFullPathNameW` and is unchanged. No public API change.