### PR TITLE
fix(semaphore): use absolute deadline for POSIX TimedWait

### DIFF
--- a/CcpSemaphore.cpp
+++ b/CcpSemaphore.cpp
@@ -97,6 +97,7 @@ CcpSemaphore::~CcpSemaphore()
 }
 
 #include <errno.h>
+#include <time.h>
 
 bool CcpSemaphore::Wait()
 {
@@ -110,8 +111,19 @@ bool CcpSemaphore::Wait()
 bool CcpSemaphore::TimedWait( uint32_t timeoutInMs )
 {
     timespec ts;
-    ts.tv_sec = timeoutInMs / 1000;
-    ts.tv_nsec = (timeoutInMs % 1000) * 1000000;
+    if( clock_gettime( CLOCK_REALTIME, &ts ) != 0 )
+    {
+        return false;
+    }
+
+    ts.tv_sec += timeoutInMs / 1000;
+    ts.tv_nsec += static_cast<long>( timeoutInMs % 1000 ) * 1000000L;
+    if( ts.tv_nsec >= 1000000000L )
+    {
+        ts.tv_sec += ts.tv_nsec / 1000000000L;
+        ts.tv_nsec %= 1000000000L;
+    }
+
     if( sem_timedwait( &m_semaphore, &ts ) == 0 )
     {
         return true;

--- a/tests/CcpSemaphore.cpp
+++ b/tests/CcpSemaphore.cpp
@@ -78,3 +78,45 @@ TEST( CcpSemaphore, CanWaitOnSemaphore )
 	EXPECT_GT( duration, 200 );
 	EXPECT_LT( duration, 1000 );
 }
+
+TEST( CcpSemaphore, TimedWaitWaitsAndReturnsFalseOnTimeout )
+{
+	CcpSemaphore s;
+
+	bool acquired = true;
+	auto duration = TimeCallInMs( [&] { acquired = s.TimedWait( 500 ); } );
+
+	EXPECT_FALSE( acquired );
+	EXPECT_GT( duration, 250 );
+	EXPECT_LT( duration, 1500 );
+}
+
+TEST( CcpSemaphore, TimedWaitReturnsTrueWhenAlreadySignaled )
+{
+	CcpSemaphore s;
+	s.Signal();
+
+	bool acquired = false;
+	auto duration = TimeCallInMs( [&] { acquired = s.TimedWait( 1000 ); } );
+
+	EXPECT_TRUE( acquired );
+	EXPECT_LT( duration, 100 );
+}
+
+TEST( CcpSemaphore, TimedWaitReturnsTrueWhenSignaledBeforeTimeout )
+{
+	CcpSemaphore s;
+
+	auto thread = [&] {
+		CcpThreadSleep( 200 );
+		s.Signal();
+	};
+	CcpCreateThread( &MakeThread<decltype( thread )>, &thread, CCP_THREAD_PRIORITY_NORMAL );
+
+	bool acquired = false;
+	auto duration = TimeCallInMs( [&] { acquired = s.TimedWait( 2000 ); } );
+
+	EXPECT_TRUE( acquired );
+	EXPECT_GT( duration, 100 );
+	EXPECT_LT( duration, 1500 );
+}


### PR DESCRIPTION
## Problem

`CcpSemaphore::TimedWait` (generic POSIX path) passed a relative duration to `sem_timedwait`, which expects an
absolute deadline against `CLOCK_REALTIME`. The computed `timespec` (`tv_sec = timeoutMs/1000`, i.e. a few seconds
after the epoch) is always far in the past, so the wait timed out immediately without ever blocking on Linux/Android —
 `TimedWait` returned `false` instantly regardless of the requested timeout. The pre-existing test
`CcpSemaphore.DefaultConstructorCreatesNonSignaledSemaphore`, which expects a ~1000 ms wait, was already failing on
the generic POSIX path because of this. macOS (mach semaphore) and Windows paths are not affected.

## Fix

`TimedWait` now derives an absolute deadline from `clock_gettime(CLOCK_REALTIME)`, adds the requested timeout, and
normalizes the nanosecond overflow before calling `sem_timedwait`. Added `#include <time.h>`.

## Tests

Added three tests in `tests/CcpSemaphore.cpp` (GoogleTest): `TimedWaitWaitsAndReturnsFalseOnTimeout` blocks ~500 ms
and returns `false` (direct regression test for the relative/absolute confusion),
`TimedWaitReturnsTrueWhenAlreadySignaled` returns `true` immediately, and
`TimedWaitReturnsTrueWhenSignaledBeforeTimeout` returns `true` when signaled from another thread before the deadline.
Reviewed manually; not compiled locally as the vcpkg toolchain is unavailable in this environment.

## Scope

Generic POSIX branch only (`#else`). macOS and Windows code paths are unchanged. No public API change.