### PR TITLE
fix(memory): detect double-free of guarded allocations on 64-bit builds

### DIFF
--- a/CCPMemory.cpp
+++ b/CCPMemory.cpp
@@ -46,6 +46,7 @@ const int CCP_MEMORY_GUARD_SIZE_BACK = 64;
 const int CCP_MEMORY_GUARD_SIZE = CCP_MEMORY_GUARD_SIZE_FRONT + CCP_MEMORY_GUARD_SIZE_BACK + sizeof( size_t );
 const uint8_t CCP_MEMORY_GUARD_VALUE_FRONT = 0xee;
 const uint8_t CCP_MEMORY_GUARD_VALUE_BACK = 0xef;
+const size_t CCP_MEMORY_FREED_PATTERN = static_cast<size_t>( 0xddddddddddddddddULL );
 
 // Should memory tracking in Telemetry be enabled? Defaults to yes. This can skew results of
 // timing analysis of functions that do a lot of allocations, such as the yaml parser.
@@ -494,7 +495,7 @@ void CCPFreeWithGuard( void* p )
 	// Get the size
 	size_t orgSize = *(size_t*)p0;
 
-	if( orgSize == 0xdddddddd )
+	if( orgSize == CCP_MEMORY_FREED_PATTERN )
 	{
 		CCP_LOGERR( "Freeing a block that was already freed at 0x%p", p );
 		CCP_DEBUG_BREAK();
@@ -596,7 +597,7 @@ void CCPAlignedFree( void* p )
 
 		if( s_guardAllocations )
 		{
-			if( (uintptr_t)allocatedPtr == 0xdddddddd )
+			if( (uintptr_t)allocatedPtr == CCP_MEMORY_FREED_PATTERN )
 			{
 				CCP_LOGERR( "Freeing an aligned block that was already freed at 0x%p", p );
 				CCP_DEBUG_BREAK();

--- a/tests/CcpMemory.cpp
+++ b/tests/CcpMemory.cpp
@@ -262,6 +262,19 @@ TEST( CcpMemory, CanDetectInvalidMemoryAccessBeforeMemoryBlock )
     }
 }
 
+TEST( CcpMemory, CanDetectDoubleFreeWithGuard )
+{
+	const size_t size = 123;
+	void* memory = CCPMallocWithGuard( size );
+	EXPECT_NE( nullptr, memory );
+	CCPFreeWithGuard( memory );
+
+	LogHelper logHelper;
+	SilencedFreeWithGuard( memory );
+
+	EXPECT_TRUE( logHelper.HasMessage( CCP::LOGTYPE_ERR, "already freed" ) );
+}
+
 TEST( CcpMemory, CanDuplicateString )
 {
 	const char* string = "just a string";


### PR DESCRIPTION
## Problem

When memory guards are enabled, `CCPFreeWithGuard` poisons the freed block with `memset(p0, 0xdd, …)` and detects a
subsequent double-free by reading back the stored size and comparing it to a sentinel: `if( orgSize == 0xdddddddd )`
(`CCPMemory.cpp`), with the same pattern in the aligned path (`if( (uintptr_t)allocatedPtr == 0xdddddddd )`).
`orgSize` is a `size_t` and `allocatedPtr` a `uintptr_t`, so on a 64-bit build a poisoned slot reads back as
`0xdddddddddddddddd`, while the literal `0xdddddddd` is only 32-bit wide. The comparison can never match, so a
double-free of a guarded allocation is never detected on any 64-bit build — i.e. the feature is silently broken on
every shipping target. Activation is Windows-only (`/memoryGuards`), so this is a concrete Windows 64-bit defect.

## Fix

Introduce a single `size_t`-wide sentinel `CCP_MEMORY_FREED_PATTERN` and compare against it at both detection sites.
The constant is defined as `static_cast<size_t>( 0xddddddddddddddddULL )`, which is correct on both 64-bit (full
width) and 32-bit (truncates to `0xdddddddd`) builds.

## Tests

Added `CanDetectDoubleFreeWithGuard` in `tests/CcpMemory.cpp`: allocate + free with guard, then free again, and assert
 the `"already freed"` error is logged. Before the fix this test fails on 64-bit (no error emitted); after the fix it
passes. It reuses the existing test infrastructure (`LogHelper`, `SilencedFreeWithGuard`) and follows the style of the
 existing guard-corruption tests. Reviewed manually; not compiled locally as the vcpkg toolchain is unavailable in
this environment.

## Scope

No public API change; only an internal constant and two comparisons. Behaviour on 32-bit builds is unchanged.