### PR TITLE
fix(callstack): guard against NULL from strchr when parsing symbols

### DIFF
--- a/CCPCallstack.cpp
+++ b/CCPCallstack.cpp
@@ -394,7 +394,7 @@ void CCPCallstack::Enumerate( void ( *callback )( size_t codePointer, const char
     {
         std::string record = lines[i];
         const char* plus = strchr( lines[i], '+' );
-        if( *plus )
+        if( plus && *plus )
         {
             std::string name;
             GetLastWord( lines[i], plus - 1, name );


### PR DESCRIPTION
## Problem

In the POSIX/macOS `backtrace_symbols` path, `CCPCallstack::Enumerate` parses each symbol line with `const char* plus
= strchr( lines[i], '+' ); if( *plus )`. When a line has no `+` (stripped binaries, static or symbol-less frames),
`strchr` returns `NULL` and `*plus` dereferences it, crashing while dumping a callstack. This path is used by macOS
(it is neither `_MSC_VER` nor `__ANDROID__`), so it is a real crash risk on a primary target — triggered when
capturing and dumping callstacks (e.g. memory-tracker reports with callstack capture enabled).

## Fix

Check the pointer before dereferencing: `if( plus && *plus )`. One-line defensive change; lines without `+` are simply
 treated as having no demangle-able suffix, same as the existing fallback.

## Tests

No dedicated test: the parser consumes `backtrace_symbols` output directly and is not injectable from a unit test, so
the no-`+` branch cannot be exercised deterministically without extracting the parser into a testable function (out of
 scope for a one-line fix). The existing `CanDumpSymbolsIntoFile` and `DepthIsEqualToItemCount` tests cover the
nominal path and guard against regressions there. Reviewed manually; not compiled locally as the vcpkg toolchain is
unavailable in this environment.

## Scope

POSIX/macOS path only. The Windows (`_MSC_VER`) and Android paths are unchanged. No public API change.