### PR TITLE
fix(memorytracker): correct StringTable search and entry sizing

### DIFF
--- a/CCPMemoryTracker.cpp
+++ b/CCPMemoryTracker.cpp
@@ -6,6 +6,7 @@
 #include "include/CcpMutex.h"
 
 #include <map>
+#include <cstddef>
 
 // #define CCP_UNIT_TEST 1
 
@@ -161,12 +162,12 @@ bool StringTable::Find( unsigned int id, unsigned int& ix )
 		const TableEntry& te = At( ix );
 		if( te.m_id < id )
 		{
-			hi = ix;
+			++ix;
+			lo = ix;
 		}
 		else if( te.m_id > id )
 		{
-			++ix;
-			lo = ix;
+			hi = ix;
 		}
 		else
 		{
@@ -174,6 +175,7 @@ bool StringTable::Find( unsigned int id, unsigned int& ix )
 		}
 	}
 
+	ix = lo;
 	return false;
 }
 
@@ -182,7 +184,7 @@ bool StringTable::AddString( unsigned int ix, unsigned int id, const char* szStr
 	CCP_ASSERT( m_pMemory );
 
 	/// First check to see if we have room for this string
-	size_t size = strlen( szString ) + sizeof( TableEntry ) + 1;
+	size_t size = strlen( szString ) + offsetof( StringEntry, m_string ) + 1;
 	size = (size + 3) & ~3;
 
 	char* pNewStringEntryBottom = (char*)m_pFirstStringEntry;
@@ -217,7 +219,7 @@ bool StringTable::AddString( unsigned int ix, unsigned int id, const char* szStr
 	pSE->m_size = size;
 	pSE->m_refCount = 1;
 	char* dst = &pSE->m_string[0];
-	strcpy_s( dst, size - sizeof( TableEntry ), szString );
+	strcpy_s( dst, size - offsetof( StringEntry, m_string ), szString );
 
 	/// Adjust the pointer for first string entry
 	m_pFirstStringEntry = pSE;


### PR DESCRIPTION
  ## Summary
  Fixes a guaranteed-wrong binary search and an arena buffer overflow in the
  memory tracker's string table.

  ## Problem
  1. `StringTable::Find` walked an `m_id`-ascending table with its comparison
     branches inverted: present ids were not found, duplicates were inserted,
     sort order broke, and `LookUp` returned garbage.
  2. `AddString` sized the `StringEntry` block with `sizeof(TableEntry)` (the
     wrong struct), omitting the `StringEntry` header, so the string was
     written past the reserved block and corrupted neighbouring entries in
     the fixed 512 KB arena.

  ## Fix
  Swap the search branches and set `ix` to the insertion point on miss.
  Size the entry from `offsetof(StringEntry, m_string)` and pass the matching
  available length to `strcpy_s`. Adds `#include <cstddef>` for `offsetof`.

  ## Type
  Correctness + memory corruption (Critical for a foundational lib).

  ## Testing
  Manual review; search now lower-bound correct, allocation accounts for the
  full variable-length-struct header.