### PR TITLE
Use Tracy with the no-crash-handler feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ target_link_libraries(CcpCore PUBLIC $<$<PLATFORM_ID:Darwin>:-framework\ AppKit>
 if(WITH_TELEMETRY)
     message(STATUS "Enabling profiler integration")
     find_package(Tracy CONFIG REQUIRED)
-    target_compile_definitions(CcpCore PUBLIC CCP_TELEMETRY_ENABLED=1 TRACY_IMPORTS TRACY_ENABLE TRACY_FIBERS TRACY_ON_DEMAND TRACY_DELAYED_INIT TRACY_MANUAL_LIFETIME)
+    target_compile_definitions(CcpCore PUBLIC CCP_TELEMETRY_ENABLED=1)
     target_link_libraries(CcpCore PUBLIC Tracy::TracyClient)
 else()
     target_compile_definitions(CcpCore PUBLIC CCP_TELEMETRY_ENABLED=0)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,13 +2,14 @@
   "dependencies": [
     {
       "name": "tracy",
-      "version>=": "0.13.1",
+      "version>=": "0.13.1#1",
       "features": [
         "fibers",
         "on-demand",
         "no-callstack",
         "manual-lifetime",
-        "delayed-init"
+        "delayed-init",
+        "no-crash-handler"
       ]
     },
     {


### PR DESCRIPTION
Also update port version of tracy to: 0.13.1#1
The #1 version contains a backported fix to 0.13.1 from tracy PR 1366.
It fixes a reconnect issue in the profiler when using feature no-callstack.