### PR TITLE
fix: detect std::atomic correctly for GCC 5+

### DIFF
--- a/include/CcpAtomic.h
+++ b/include/CcpAtomic.h
@@ -14,7 +14,7 @@
 #endif
 
 #ifdef __GNUG__
-	#if __GNUC__ == 4 && __GNUC_MINOR__ >= 7
+	#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 7)
 		#define CCP_HAS_ATOMIC 1
 	#endif
 #endif


### PR DESCRIPTION
`#if` statement was configured too strict, preventing the detection of `std::atomic` for GCC 5 and onward.

Although I am like 99% sure the whole if-statement could be removed, as GCC 4.7 is like ... ancient. March 22, 2012, to be exact. If you like, I can just also remove the if-statement all together. For now, I just fixed what was broken :)

---

Full disclosure: I work for Fenris Creations, although I have no involved with the Carbon project. I work on this in my free time under my own name.