### PR TITLE
modernize: replace C-style cast with reinterpret_cast in TimeNow

### DIFF
--- a/CcpTime.cpp
+++ b/CcpTime.cpp
@@ -60,10 +60,12 @@ bool TimeFromDateTime( CcpTime& timeStamp, const CcpDateTime& dateTime )
 CcpTime TimeNow()
 {
 	CcpTime time = 0;
-	GetSystemTimeAsFileTime( (FILETIME*)&time );
+
+	// Moved to reinterpret-cast to make the pointer conversion explicit
+	// GetSystemTimeAsFileTime( (FILETIME*)&time );
+	GetSystemTimeAsFileTime( reinterpret_cast<FILETIME*>( &time ) );
 	return time;
 }
-
 
 #elif defined(__APPLE__)
 


### PR DESCRIPTION
Modernized the pointer conversion inside TimeNow() from a c-style cast to an explicit reinterpret_cast.