### PR TITLE
Improve utility code clarity and add CcpTruncateFile

### DIFF
--- a/CCPLog.cpp
+++ b/CCPLog.cpp
@@ -12,9 +12,9 @@
 
 constexpr size_t LOG_ERROR_BUFFER_SIZE = 256;
 constexpr size_t LOG_LOCAL_BUFFER_SIZE = 256;
-constexpr size_t LARGE_BUFFER_SIZE = 65535;
+constexpr size_t LOG_LARGE_BUFFER_SIZE = 65535;
 
-char s_largeBuffer[LARGE_BUFFER_SIZE]{};
+char s_largeBuffer[LOG_LARGE_BUFFER_SIZE]{};
 
 namespace
 {
@@ -233,7 +233,7 @@ CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type,
 
 		output = s_largeBuffer;
 		vsnprintf( output, std::extent_v<decltype(s_largeBuffer)>, format, argCopy2 );
-		assert( s_largeBuffer[LARGE_BUFFER_SIZE - 1] == '\0' );
+		assert( s_largeBuffer[LOG_LARGE_BUFFER_SIZE - 1] == '\0' );
 	}
 
 	LogFuncChannelRaw( logObject, type, userData, output );

--- a/CCPLog.cpp
+++ b/CCPLog.cpp
@@ -10,12 +10,15 @@
 	#include <windows.h>
 #endif
 
+constexpr size_t LOG_ERROR_BUFFER_SIZE = 256;
+constexpr size_t LOG_LOCAL_BUFFER_SIZE = 256;
 constexpr size_t LARGE_BUFFER_SIZE = 65535;
+
 char s_largeBuffer[LARGE_BUFFER_SIZE]{};
 
 namespace
 {
-	char s_lastError[ 256 ] = "";
+	char s_lastError[ LOG_ERROR_BUFFER_SIZE ] = "";
 
 	struct LogEchoFuncEntry
 	{
@@ -214,7 +217,7 @@ CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type,
     va_copy( argCopy2, args );
 #endif
     
-	char localBuffer[256];
+	char localBuffer[LOG_LOCAL_BUFFER_SIZE];
 	char* output = localBuffer;
 	if ( vsnprintf( localBuffer, std::extent_v<decltype(localBuffer)>, format, args ) > ( std::extent_v<decltype(localBuffer)> - 1 ) )
 	{
@@ -230,7 +233,7 @@ CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type,
 
 		output = s_largeBuffer;
 		vsnprintf( output, std::extent_v<decltype(s_largeBuffer)>, format, argCopy2 );
-		assert( s_largeBuffer[LARGE_BUFFER_SIZE] == '\0' );
+		assert( s_largeBuffer[LARGE_BUFFER_SIZE - 1] == '\0' );
 	}
 
 	LogFuncChannelRaw( logObject, type, userData, output );

--- a/CCPLog.cpp
+++ b/CCPLog.cpp
@@ -10,7 +10,8 @@
 	#include <windows.h>
 #endif
 
-char s_largeBuffer[65535]{};
+constexpr size_t LARGE_BUFFER_SIZE = 65535;
+char s_largeBuffer[LARGE_BUFFER_SIZE]{};
 
 namespace
 {
@@ -229,7 +230,7 @@ CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type,
 
 		output = s_largeBuffer;
 		vsnprintf( output, std::extent_v<decltype(s_largeBuffer)>, format, argCopy2 );
-		assert( s_largeBuffer[65534] == '\0' );
+		assert( s_largeBuffer[LARGE_BUFFER_SIZE] == '\0' );
 	}
 
 	LogFuncChannelRaw( logObject, type, userData, output );

--- a/CcpFileUtils.cpp
+++ b/CcpFileUtils.cpp
@@ -76,6 +76,16 @@ void CcpCloseFile( int fd )
 	_close( fd );
 }
 
+bool CcpTruncateFile(const std::wstring& filename) {
+	int fd = CcpCreateFile( filename.c_str(), CCP_SM_RWSHARING );
+	if( fd < 0 )
+	{
+		return false;
+	}
+	CcpCloseFile( fd );
+	return true;
+}
+
 ssize_t CcpReadFromFile( int fd, void* buf, size_t numBytes )
 {
 	return _read( fd, buf, (unsigned int)numBytes );
@@ -166,6 +176,17 @@ int CcpCreateFile( const wchar_t* filename, CcpShareMode shareMode )
 void CcpCloseFile( int fd )
 {
 	close( fd );
+}
+
+bool CcpTruncateFile( const std::wstring& filename )
+{
+	int fd = CcpCreateFile( filename.c_str(), CCP_SM_RWSHARING );
+	if( fd < 0 )
+	{
+		return false;
+	}
+	CcpCloseFile( fd );
+	return true;
 }
 
 ssize_t CcpReadFromFile( int fd, void* buf, size_t numBytes )

--- a/CcpTime.cpp
+++ b/CcpTime.cpp
@@ -60,10 +60,12 @@ bool TimeFromDateTime( CcpTime& timeStamp, const CcpDateTime& dateTime )
 CcpTime TimeNow()
 {
 	CcpTime time = 0;
-	GetSystemTimeAsFileTime( (FILETIME*)&time );
+
+	// Moved to reinterpret-cast to make the pointer conversion explicit
+	// GetSystemTimeAsFileTime( (FILETIME*)&time );
+	GetSystemTimeAsFileTime( reinterpret_cast<FILETIME*>( &time ) );
 	return time;
 }
-
 
 #elif defined(__APPLE__)
 

--- a/include/CcpFileUtils.h
+++ b/include/CcpFileUtils.h
@@ -54,6 +54,7 @@ CARBON_CORE_API std::wstring CcpExecutablePath();
 CARBON_CORE_API int CcpOpenFile( const wchar_t* filename, CcpOpenMode mode, CcpShareMode shareMode );
 CARBON_CORE_API int CcpCreateFile( const wchar_t* filename, CcpShareMode shareMode );
 CARBON_CORE_API void CcpCloseFile( int fd );
+CARBON_CORE_API bool CcpTruncateFile( const std::wstring& filename );
 CARBON_CORE_API ssize_t CcpReadFromFile( int fd, void* buf, size_t numBytes );
 CARBON_CORE_API ssize_t CcpWriteToFile( int fd, const void* buf, size_t numBytes );
 CARBON_CORE_API off_t CcpLseek( int fd, off_t offset, int whence );


### PR DESCRIPTION
Added `CcpTruncateFile` as an explicit API for clearing file contents. This avoids requiring users to know that `CcpCreateFile` internally uses `_O_TRUNC`, making the truncation behavior clearer at the call site.

The current implementation reuses `CcpCreateFile` to preserve the existing behavior and avoid duplicating file creation logic. If the preferred approach is to handle truncation directly inside `CcpTruncateFile`, I can adjust it.

Additional cleanup:
- Replaced hardcoded buffer sizes in the logging implementation with named `constexpr` values for improved readability and maintainability.
- Replaced a C-style pointer cast with `reinterpret_cast` in the time implementation to make the intent of the conversion explicit.