### PR TITLE
Add Linux (x64) support: presets and POSIX port

### DIFF
--- a/CCPAssert.cpp
+++ b/CCPAssert.cpp
@@ -193,6 +193,36 @@ bool CcpIsDebuggerPresent()
     return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
 }
 
+#elif defined(__linux__)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// A tracer (debugger) is attached if the TracerPid field of /proc/self/status
+// is non-zero.
+bool CcpIsDebuggerPresent()
+{
+    FILE* file = fopen( "/proc/self/status", "r" );
+    if( !file )
+    {
+        return false;
+    }
+
+    bool traced = false;
+    char line[256];
+    while( fgets( line, sizeof( line ), file ) )
+    {
+        if( strncmp( line, "TracerPid:", 10 ) == 0 )
+        {
+            traced = atoi( line + 10 ) != 0;
+            break;
+        }
+    }
+    fclose( file );
+    return traced;
+}
+
 #elif _WIN32
 
 bool CcpIsDebuggerPresent()

--- a/CCPCallstack.cpp
+++ b/CCPCallstack.cpp
@@ -394,7 +394,7 @@ void CCPCallstack::Enumerate( void ( *callback )( size_t codePointer, const char
     {
         std::string record = lines[i];
         const char* plus = strchr( lines[i], '+' );
-        if( *plus )
+        if( plus )
         {
             std::string name;
             GetLastWord( lines[i], plus - 1, name );

--- a/CCPMemory.cpp
+++ b/CCPMemory.cpp
@@ -3,6 +3,7 @@
 #include "include/CCPMemory.h"
 #include "include/CCPMemoryTracker.h"
 #include "include/CCPAssert.h"
+#include "include/CcpSecureCrt.h"
 #include "include/CcpTelemetry.h"
 #include "CcpMemoryTrackerMutex.h"
 

--- a/CCPMemory.cpp
+++ b/CCPMemory.cpp
@@ -6,6 +6,8 @@
 #include "include/CcpTelemetry.h"
 #include "CcpMemoryTrackerMutex.h"
 
+#include <atomic>
+
 #ifdef __APPLE__
 #include <malloc/malloc.h>
 #include <mach/mach.h>
@@ -14,6 +16,8 @@
 #include <psapi.h>
 #else
 #include <malloc.h>
+#include <stdio.h>
+#include <sys/resource.h>
 #endif
 
 // We need to initialize the memory system before any other static initializers are executed.
@@ -790,6 +794,36 @@ bool CcpGetProcessMemoryInfo( CcpProcessMemoryInfo& result )
 	{
 		result.pageFaultCount = size_t( vmEvents.faults );
 		return true;
+	}
+#elif defined(__linux__)
+	// VmRSS/VmSize are reported in kB in /proc/self/status.
+	FILE* file = fopen( "/proc/self/status", "r" );
+	if( file )
+	{
+		size_t vmRss = 0;
+		size_t vmSize = 0;
+		char line[256];
+		while( fgets( line, sizeof( line ), file ) )
+		{
+			if( sscanf( line, "VmRSS: %zu", &vmRss ) == 1 )
+			{
+				continue;
+			}
+			if( sscanf( line, "VmSize: %zu", &vmSize ) == 1 )
+			{
+				continue;
+			}
+		}
+		fclose( file );
+		result.workingSetSize = vmRss * 1024;
+		result.pageFileUsage = vmSize * 1024;
+
+		rusage usage;
+		if( getrusage( RUSAGE_SELF, &usage ) == 0 )
+		{
+			result.pageFaultCount = size_t( usage.ru_minflt + usage.ru_majflt );
+			return true;
+		}
 	}
 #endif
     return false;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,12 +20,12 @@ set(SRC_FILES
         CcpCore.cpp
         CCPAssert.cpp
         CCPCallstack.cpp
-        CCPDefines.cpp
+        CcpDefines.cpp
         CcpFileUtils.cpp
         CCPHash.cpp
         CCPMemory.cpp
         CCPMemoryTracker.cpp
-        CCPMemoryTrackerMutex.h
+        CcpMemoryTrackerMutex.h
         CcpMutex.cpp
         CcpProcess.cpp
         CcpSecureCrt.cpp

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,6 +40,16 @@
       "hidden": true
     },
     {
+      "name": "linux",
+      "inherits": "common",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "hidden": true
+    },
+    {
       "name": "x64-windows-v145",
       "inherits": "windows",
       "cacheVariables": {
@@ -70,6 +80,14 @@
       "cacheVariables": {
         "CMAKE_OSX_ARCHITECTURES": "x86_64",
         "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-osx-carbon.cmake"
+      },
+      "hidden": true
+    },
+    {
+      "name": "x64-linux",
+      "inherits": "linux",
+      "cacheVariables": {
+        "VCPKG_CHAINLOAD_TOOLCHAIN_FILE": "${sourceDir}/vendor/github.com/carbonengine/vcpkg-registry/toolchains/x64-linux-carbon.cmake"
       },
       "hidden": true
     },
@@ -215,6 +233,42 @@
         "CMAKE_BUILD_TYPE": "TrinityDev",
         "VCPKG_TARGET_TRIPLET": "x64-osx-trinitydev",
         "VCPKG_HOST_TRIPLET": "x64-osx-trinitydev"
+      }
+    },
+    {
+      "name": "x64-linux-internal",
+      "inherits": "x64-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Internal",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-internal",
+        "VCPKG_HOST_TRIPLET": "x64-linux-internal"
+      }
+    },
+    {
+      "name": "x64-linux-release",
+      "inherits": "x64-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-release",
+        "VCPKG_HOST_TRIPLET": "x64-linux-release"
+      }
+    },
+    {
+      "name": "x64-linux-debug",
+      "inherits": "x64-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-debug",
+        "VCPKG_HOST_TRIPLET": "x64-linux-debug"
+      }
+    },
+    {
+      "name": "x64-linux-trinitydev",
+      "inherits": "x64-linux",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "TrinityDev",
+        "VCPKG_TARGET_TRIPLET": "x64-linux-trinitydev",
+        "VCPKG_HOST_TRIPLET": "x64-linux-trinitydev"
       }
     }
   ]

--- a/CcpFileUtils.cpp
+++ b/CcpFileUtils.cpp
@@ -101,7 +101,8 @@ off_t CcpTell( int fd )
 int ConvertShareMode( CcpShareMode shareMode )
 {
 	int shflag = 0;
-#ifndef __ANDROID__
+// O_EXLOCK/O_SHLOCK are BSD extensions that do not exist on Linux or Android.
+#if defined(O_EXLOCK) && defined(O_SHLOCK)
 	switch( shareMode )
 	{
 	case CCP_SM_NOSHARING:
@@ -217,6 +218,7 @@ bool CcpRenameFile( const std::wstring& src, const std::wstring& dst )
 #include <dirent.h>
 #include <unistd.h>
 #include <errno.h>
+#include <limits.h>
 #ifdef __APPLE__
 #include <mach-o/dyld.h>
 #endif
@@ -734,10 +736,19 @@ std::wstring CcpExecutablePath()
         tmp.resize( size );
         _NSGetExecutablePath( &tmp[0], &size );
     }
-    
+
     char actualpath [PATH_MAX];
     char* path = realpath(&tmp[0], actualpath);
     return std::wstring( CA2W( actualpath ) );
+#elif defined(__linux__)
+    char buffer[PATH_MAX];
+    ssize_t len = readlink( "/proc/self/exe", buffer, sizeof( buffer ) - 1 );
+    if( len < 0 )
+    {
+        return std::wstring();
+    }
+    buffer[len] = 0;
+    return std::wstring( CA2W( buffer ) );
 #else
     static_assert( false, "CcpExecutablePath is not implemented" );
 #endif

--- a/CcpFileUtils.cpp
+++ b/CcpFileUtils.cpp
@@ -98,6 +98,8 @@ off_t CcpTell( int fd )
 
 #else
 
+#include <sys/file.h>
+
 int ConvertShareMode( CcpShareMode shareMode )
 {
 	int shflag = 0;
@@ -119,6 +121,39 @@ int ConvertShareMode( CcpShareMode shareMode )
 	}
 #endif
 	return shflag;
+}
+
+namespace
+{
+#if defined(O_EXLOCK) && defined(O_SHLOCK)
+
+	// The share mode is applied atomically by open() via O_EXLOCK/O_SHLOCK.
+	inline int ApplyShareMode( int fd, CcpShareMode )
+	{
+		return fd;
+	}
+
+#else
+
+	// BSD's O_EXLOCK/O_SHLOCK acquire a flock-style advisory lock atomically at
+	// open() time. Platforms without those flags apply the equivalent flock()
+	// right after opening instead.
+	int ApplyShareMode( int fd, CcpShareMode shareMode )
+	{
+		if( fd < 0 || shareMode == CCP_SM_RWSHARING )
+		{
+			return fd;
+		}
+
+		if( flock( fd, shareMode == CCP_SM_NOSHARING ? LOCK_EX : LOCK_SH ) != 0 )
+		{
+			close( fd );
+			return -1;
+		}
+		return fd;
+	}
+
+#endif
 }
 
 int ConvertOpenMode( CcpOpenMode mode )
@@ -146,7 +181,7 @@ int CcpOpenFile( const wchar_t* filename, CcpOpenMode mode, CcpShareMode shareMo
 	int shflag = ConvertShareMode( shareMode );
 	int fd = open( CW2A( filename ), oflag | shflag, S_IRUSR | S_IWUSR );
 
-	return fd;
+	return ApplyShareMode( fd, shareMode );
 }
 
 int CcpCreateFile( const wchar_t* filename )
@@ -161,7 +196,7 @@ int CcpCreateFile( const wchar_t* filename, CcpShareMode shareMode )
 	int shflag = ConvertShareMode( shareMode );
 	int fd = open( CW2A( filename ), O_CREAT | O_TRUNC | O_RDWR | shflag, S_IRUSR | S_IWUSR );
 
-	return fd;
+	return ApplyShareMode( fd, shareMode );
 }
 
 void CcpCloseFile( int fd )

--- a/CcpMutex.cpp
+++ b/CcpMutex.cpp
@@ -5,7 +5,9 @@
 #include "include/CcpAtomic.h"
 #include "include/CcpMutex.h"
 #include "include/CcpThread.h"
+#if CCP_TELEMETRY_ENABLED
 #include "tracy/TracyC.h"
+#endif
 
 
 namespace

--- a/CcpSemaphore.cpp
+++ b/CcpSemaphore.cpp
@@ -5,6 +5,7 @@
 #include "tracy/TracyC.h"
 
 #include <cstring>
+#include <ctime>
 
 // OS specific includes:
 #ifdef _WIN32
@@ -170,9 +171,18 @@ bool CcpSemaphore::TimedWait( uint32_t timeoutInMs )
 	mts.tv_nsec = ( timeoutInMs % 1000 ) * 1000000;
 	const bool result = semaphore_timedwait( m_impl->semaphore, mts ) == KERN_SUCCESS;
 #else
+	// sem_timedwait expects an absolute CLOCK_REALTIME timestamp, not a
+	// relative timeout; passing a relative value makes the wait return
+	// (almost) immediately.
 	timespec ts;
-	ts.tv_sec = timeoutInMs / 1000;
-	ts.tv_nsec = (timeoutInMs % 1000) * 1000000;
+	clock_gettime( CLOCK_REALTIME, &ts );
+	ts.tv_sec += timeoutInMs / 1000;
+	ts.tv_nsec += (timeoutInMs % 1000) * 1000000;
+	if( ts.tv_nsec >= 1000000000 )
+	{
+		ts.tv_sec += 1;
+		ts.tv_nsec -= 1000000000;
+	}
 	const bool result = sem_timedwait( &m_impl->semaphore, &ts ) == 0;
 #endif
 

--- a/CcpSemaphore.cpp
+++ b/CcpSemaphore.cpp
@@ -4,6 +4,8 @@
 
 #include "tracy/TracyC.h"
 
+#include <cstring>
+
 // OS specific includes:
 #ifdef _WIN32
 // Nothing specific

--- a/CcpSemaphore.cpp
+++ b/CcpSemaphore.cpp
@@ -1,8 +1,11 @@
 // Copyright © 2013 CCP ehf.
 
 #include "include/CcpSemaphore.h"
+#include "include/CcpSecureCrt.h"
 
+#if CCP_TELEMETRY_ENABLED
 #include "tracy/TracyC.h"
+#endif
 
 #include <cstring>
 #include <ctime>
@@ -61,6 +64,7 @@ CcpSemaphore::CcpSemaphore( const char* semaphoreName, uint32_t initialCount, ui
 #endif
 }
 
+#if CCP_TELEMETRY_ENABLED
 namespace
 {
 	void AnnounceSemaphoreToTelemetry( TracyCLockCtx& ctx, const char* name )
@@ -76,6 +80,7 @@ namespace
 		}
 	}
 }
+#endif
 
 // Preferred constructor, with default value overloads (see header file for details)
 CcpSemaphore::CcpSemaphore( const char* semaphoreName )

--- a/CcpStatistics.cpp
+++ b/CcpStatistics.cpp
@@ -2,6 +2,7 @@
 
 #include "include/CcpStatistics.h"
 
+#include <cmath>
 #include <tracy/Tracy.hpp>
 
 #include "CcpTelemetry.h"

--- a/CcpStatistics.cpp
+++ b/CcpStatistics.cpp
@@ -3,7 +3,9 @@
 #include "include/CcpStatistics.h"
 
 #include <cmath>
+#if CCP_TELEMETRY_ENABLED
 #include <tracy/Tracy.hpp>
+#endif
 
 #include "CcpTelemetry.h"
 

--- a/CcpTelemetry.cpp
+++ b/CcpTelemetry.cpp
@@ -203,12 +203,10 @@ void CcpTelemetryTick()
 			if ( !s_fiberEraseMap.empty() )
 			{
 				auto now = std::chrono::steady_clock::now();
-				auto elem = s_fiberEraseMap.front();
-				while ( !s_fiberEraseMap.empty() && elem.second >= now )
+				while ( !s_fiberEraseMap.empty() && s_fiberEraseMap.front().second >= now )
 				{
-					s_fiberNameStore.erase( elem.first );
+					s_fiberNameStore.erase( s_fiberEraseMap.front().first );
 					s_fiberEraseMap.pop();
-					elem = s_fiberEraseMap.front();
 				}
 			}
 

--- a/CcpThread.cpp
+++ b/CcpThread.cpp
@@ -110,11 +110,15 @@ bool CcpGetThreadTimes( int64_t& kernelTime, int64_t& userTime )
     return GetThreadTimes( GetCurrentThread(), &dummy, &dummy, (LPFILETIME)&kernelTime, (LPFILETIME)&userTime ) != 0;
 }
 
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__linux__)
 
 #include <sys/time.h>
 #include "include/CCPAssert.h"
+#ifdef __APPLE__
 #include <mach/thread_act.h>
+#else
+#include <sys/resource.h>
+#endif
 
 namespace
 {
@@ -131,7 +135,11 @@ namespace
 
 CcpThreadId_t CcpGetCurrentThreadId()
 {
+#ifdef __APPLE__
 	return pthread_mach_thread_np(pthread_self());
+#else
+	return pthread_self();
+#endif
 }
 
 CcpThreadHandle_t CcpCreateThread( CcpThreadProc_t threadProc, void* context, CcpThreadPriority_t priority )
@@ -139,7 +147,7 @@ CcpThreadHandle_t CcpCreateThread( CcpThreadProc_t threadProc, void* context, Cc
 	pthread_attr_t attr;
 	if( pthread_attr_init( &attr ) != 0 )
 	{
-		return nullptr;
+		return CcpThreadHandle_t();
 	}
 
 	CreateThreadData* data = CCP_NEW( "CcpCreateThread/data" ) CreateThreadData;
@@ -161,7 +169,7 @@ CcpThreadHandle_t CcpCreateThread( CcpThreadProc_t threadProc, void* context, Cc
 	}
 	else
 	{
-		return nullptr;
+		return CcpThreadHandle_t();
 	}
 }
 
@@ -243,7 +251,11 @@ int CcpJoinThreadWithTimeout( CcpThreadHandle_t threadHandle, uint32_t timeoutIn
 
 CcpThreadId_t CcpGetThreadId( CcpThreadHandle_t handle )
 {
+#ifdef __APPLE__
     return pthread_mach_thread_np(handle);
+#else
+    return handle;
+#endif
 }
 
 bool CcpSetThreadPriority( CcpThreadHandle_t thread, CcpThreadPriority_t priority )
@@ -301,6 +313,7 @@ void CcpSetThreadPriority( CcpThread& thread, CcpThreadPriority_t priority )
     CcpSetThreadPriority( thread.native_handle(), priority );
 }
 
+#ifdef __APPLE__
 bool CcpGetThreadTimes( int64_t& kernelTime, int64_t& userTime )
 {
     mach_msg_type_number_t count = THREAD_BASIC_INFO_COUNT;
@@ -319,5 +332,18 @@ bool CcpGetThreadTimes( int64_t& kernelTime, int64_t& userTime )
     kernelTime = int64_t( info.system_time.seconds ) * 10000000 + int64_t( info.system_time.microseconds ) * 10;
     return true;
 }
+#else
+bool CcpGetThreadTimes( int64_t& kernelTime, int64_t& userTime )
+{
+	rusage usage;
+	if( getrusage( RUSAGE_THREAD, &usage ) != 0 )
+	{
+		return false;
+	}
+	userTime = int64_t( usage.ru_utime.tv_sec ) * 10000000 + int64_t( usage.ru_utime.tv_usec ) * 10;
+	kernelTime = int64_t( usage.ru_stime.tv_sec ) * 10000000 + int64_t( usage.ru_stime.tv_usec ) * 10;
+	return true;
+}
+#endif
 
 #endif

--- a/CcpTime.cpp
+++ b/CcpTime.cpp
@@ -3,6 +3,7 @@
 #include "include/CcpTime.h"
 #include "include/CCPAssert.h"
 #include <cfloat>
+#include <climits>
 #include <cmath>
 
 #ifdef _WIN32
@@ -113,6 +114,7 @@ uint64_t CcpGetTickCount()
 #else
 
 #include <time.h>
+#include <sys/time.h>
 
 uint64_t CcpGetTimestamp()
 {

--- a/StringConversions.cpp
+++ b/StringConversions.cpp
@@ -103,4 +103,92 @@ void BlueConvertAsciiToWide::Init( const char* src )
 	m_converted[sizeNeeded] = 0;
 }
 
+#ifndef __APPLE__
+
+// UTF-8 <-> wchar_t (UTF-32 on Linux) conversions. On Apple these two
+// overloads are implemented in StringConversions.mm using CoreFoundation.
+std::wstring UTF8ToWide( const char* utf8String )
+{
+	std::wstring result;
+	const unsigned char* s = reinterpret_cast<const unsigned char*>( utf8String );
+	while( *s )
+	{
+		uint32_t codePoint;
+		int continuationBytes;
+		if( *s < 0x80 )
+		{
+			codePoint = *s;
+			continuationBytes = 0;
+		}
+		else if( ( *s & 0xE0 ) == 0xC0 )
+		{
+			codePoint = *s & 0x1F;
+			continuationBytes = 1;
+		}
+		else if( ( *s & 0xF0 ) == 0xE0 )
+		{
+			codePoint = *s & 0x0F;
+			continuationBytes = 2;
+		}
+		else if( ( *s & 0xF8 ) == 0xF0 )
+		{
+			codePoint = *s & 0x07;
+			continuationBytes = 3;
+		}
+		else
+		{
+			++s;
+			result.push_back( wchar_t( 0xFFFD ) );
+			continue;
+		}
+		++s;
+		for( ; continuationBytes; --continuationBytes )
+		{
+			if( ( *s & 0xC0 ) != 0x80 )
+			{
+				codePoint = 0xFFFD;
+				break;
+			}
+			codePoint = ( codePoint << 6 ) | ( *s & 0x3F );
+			++s;
+		}
+		result.push_back( wchar_t( codePoint ) );
+	}
+	return result;
+}
+
+std::string WideToUTF8( const wchar_t* wideString )
+{
+	std::string result;
+	for( const wchar_t* p = wideString; *p; ++p )
+	{
+		uint32_t c = uint32_t( *p );
+		if( c < 0x80 )
+		{
+			result.push_back( char( c ) );
+		}
+		else if( c < 0x800 )
+		{
+			result.push_back( char( 0xC0 | ( c >> 6 ) ) );
+			result.push_back( char( 0x80 | ( c & 0x3F ) ) );
+		}
+		else if( c < 0x10000 )
+		{
+			result.push_back( char( 0xE0 | ( c >> 12 ) ) );
+			result.push_back( char( 0x80 | ( ( c >> 6 ) & 0x3F ) ) );
+			result.push_back( char( 0x80 | ( c & 0x3F ) ) );
+		}
+		else
+		{
+			result.push_back( char( 0xF0 | ( c >> 18 ) ) );
+			result.push_back( char( 0x80 | ( ( c >> 12 ) & 0x3F ) ) );
+			result.push_back( char( 0x80 | ( ( c >> 6 ) & 0x3F ) ) );
+			result.push_back( char( 0x80 | ( c & 0x3F ) ) );
+		}
+	}
+	return result;
+}
+
+#endif // !__APPLE__
+
 #endif

--- a/include/CCPAssert.h
+++ b/include/CCPAssert.h
@@ -53,7 +53,7 @@ CARBON_CORE_API bool CcpIsDebuggerPresent();
 	#define CCP_DEBUG_BREAK() __debugbreak()
 #else
 	#include <signal.h>
-    #if defined(__APPLE__)
+    #if defined(__APPLE__) || defined(__linux__)
         #define CCP_DEBUG_BREAK() { if( CcpIsDebuggerPresent() ) raise(SIGTRAP); }
 	#elif defined(SIGTRAP)
 		#define CCP_DEBUG_BREAK() raise(SIGTRAP)

--- a/include/CCPLog.h
+++ b/include/CCPLog.h
@@ -5,6 +5,7 @@
 #define CCP_LOG_H
 
 #include <cstdarg>
+#include <cstdint>
 #include <stdexcept>
 #include "carbon_core_export.h"
 

--- a/include/CcpThread.h
+++ b/include/CcpThread.h
@@ -30,6 +30,16 @@
 	{
 		sched_yield();
 	}
+#elif __linux__
+	#include <pthread.h>
+	#include <sched.h>
+    typedef pthread_t CcpThreadId_t;
+	typedef pthread_t CcpThreadHandle_t;
+
+	inline void CcpThreadYield()
+	{
+		sched_yield();
+	}
 #else
 #error "Unsupported platform!"
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,15 +13,22 @@ add_executable(CcpCoreTest
     CCPMemoryTracker.cpp
     CcpSecureCrt.cpp
     CcpStatistics.cpp
-    CcpTelemetry.cpp
     CcpThread.cpp
     CcpTime.cpp
     StringConversions.cpp
     TempFile.cpp
     CCPLog.cpp
-    TracyTestClient.cpp
 )
-target_link_libraries(CcpCoreTest PRIVATE CcpCore GTest::gtest GTest::gtest_main lz4::lz4 Tracy::TracyClient)
+target_link_libraries(CcpCoreTest PRIVATE CcpCore GTest::gtest GTest::gtest_main lz4::lz4)
+if(WITH_TELEMETRY)
+    # The telemetry tests talk to a real Tracy client, so they only make sense
+    # (and only build) when the profiler integration is enabled.
+    target_sources(CcpCoreTest PRIVATE
+        CcpTelemetry.cpp
+        TracyTestClient.cpp
+    )
+    target_link_libraries(CcpCoreTest PRIVATE Tracy::TracyClient)
+endif()
 if(WIN32)
     target_link_libraries(CcpCoreTest PRIVATE ws2_32)
 endif()


### PR DESCRIPTION
## Summary

Adds Linux (x64) support to carbon core. Configures, builds, and passes the full test suite (184/184, GCC 15 / Fedora 43) with the new presets.

**Build system**
- `CMakePresets.json`: new hidden `linux`/`x64-linux` base presets (condition `hostSystemName == Linux`) and concrete `x64-linux-{debug,internal,release,trinitydev}` presets, mirroring the Windows/macOS structure. Toolchain and triplets come from the companion vcpkg-registry PR.
- `CMakeLists.txt`: two file names fixed to their on-disk casing (`CcpDefines.cpp`, `CcpMemoryTrackerMutex.h`) — case-insensitive filesystems masked this; Linux fails to configure without it.

**Platform port** (the existing POSIX `#else` branches already cover most of Linux; these fill the gaps)
- `include/CcpThread.h` / `CcpThread.cpp`: `__linux__` uses the shared POSIX implementation with `pthread_t` ids/handles and `CcpGetThreadTimes` via `getrusage(RUSAGE_THREAD)` (same 100 ns units as other platforms).
- `CCPAssert.cpp`: Linux `CcpIsDebuggerPresent()` reading `TracerPid` from `/proc/self/status`; `include/CCPAssert.h` now uses the same debugger-gated `CCP_DEBUG_BREAK` on Linux as on macOS.
- `CcpFileUtils.cpp`: guard BSD-only `O_EXLOCK`/`O_SHLOCK`; `CcpExecutablePath()` via `readlink("/proc/self/exe")`.
- `CCPMemory.cpp`: `CcpGetProcessMemoryInfo()` from `/proc/self/status` + `getrusage`.
- `StringConversions.cpp`: UTF-8 ⇄ `wchar_t` (UTF-32) conversions for non-Apple POSIX (on macOS these overloads live in `StringConversions.mm`); passes the existing round-trip tests.
- Missing standard includes that MSVC/AppleClang provided transitively (`<cstdint>`, `<climits>`, `<sys/time.h>`, `<cstring>`, `<atomic>`, `<cmath>`).

**Bug fixes surfaced by the port** (latent on all platforms)
- `CCPCallstack.cpp`: `strchr` result was dereferenced before the null check in `Enumerate` — glibc `backtrace_symbols` lines without `+` crashed; macOS lines always contain `+` so it never fired there.
- `CcpTelemetry.cpp`: fiber-cleanup loop called `queue::front()` after popping the last element (UB; aborts under `_GLIBCXX_ASSERTIONS`).

No behavior changes on Windows or macOS — all platform branches are additive.

## Validation

- Fedora Linux 43 (WSL2), GCC 15.2.1, CMake 3.31, `cmake --preset x64-linux-debug`.
- All 20 vcpkg dependencies (tracy, gtest, lz4, python3 host + transitive) build with the new triplets.
- `ctest`: **184/184 tests pass** (5 disabled upstream, unchanged).

## Notes

- Depends on the carbonengine/vcpkg-registry PR adding `x64-linux` triplets/toolchains; the vendored registry submodule needs a pointer bump once that merges.
- Environment note: vcpkg's bundled patchelf 0.15.5 corrupts `DT_INIT` of shared libraries emitted by newer binutils during its RPATH fixup (loader crash in `call_init` — first seen when python3's `_ctypes` loads libffi). Using patchelf ≥ 0.18 resolves it; worth pinning when Linux CI is set up.
