### PR TITLE
Add test case for `CcpCrashOnPurpose`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ find_package(lz4 CONFIG REQUIRED)
 add_executable(CcpCoreTest
     CCPCallstack.cpp
     CcpCoreTest.cpp
+    CcpCrash.cpp
     CCPHash.cpp
     CcpFileUtils.cpp
     CcpMemory.cpp

--- a/tests/CcpCrash.cpp
+++ b/tests/CcpCrash.cpp
@@ -1,0 +1,12 @@
+// Copyright © 2026 CCP ehf.
+
+#include <gtest/gtest.h>
+
+#include <CcpCrash.h>
+
+class CcpCrashDeathTest : public ::testing::Test {};
+
+TEST_F( CcpCrashDeathTest, CrashOnPurpose )
+{
+	EXPECT_DEATH( CcpCrashOnPurpose(), "" );
+}


### PR DESCRIPTION
Good to have a test for this because its behaviour may change depending on the platform it runs on.