### PR TITLE
Include string in CcpTelemetry.h

### DIFF
--- a/include/CcpTelemetry.h
+++ b/include/CcpTelemetry.h
@@ -4,6 +4,8 @@
 #ifndef CcpTelemetry_h
 #define CcpTelemetry_h
 
+#include <string>
+
 #include "CcpColorConstants.h"
 #include "CcpThread.h"
 #include "carbon_core_export.h"


### PR DESCRIPTION
Not including `<string>` relies on undefined behaviour from the v141 MSVC compiler where string is included as a transitive dependency through other includes.

This no longer happens, and breaks in later compiler versions and later versions of the Windows SDK.

Required change for carbon-audio. Since this now uses a later version of the MSVC compiler.