### PR TITLE
Use HTTPS for the vcpkg registry

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,9 +7,13 @@
   "registries": [
     {
       "kind": "git",
-      "repository": "git@github.com:carbonengine/vcpkg-registry.git",
+      "repository": "https://github.com/carbonengine/vcpkg-registry.git",
       "baseline": "d431d05377ae8d620c644c49c3f4d1bd974cee18",
-      "packages": ["python3", "ccp-debug-info", "tracy"]
+      "packages": [
+        "python3",
+        "ccp-debug-info",
+        "tracy"
+      ]
     }
   ]
 }


### PR DESCRIPTION
For vcpkg, it is much more common to use HTTPS for public registries.
Accessing them via SSH isn't always possible (different protocol) and requires setup of keys with GitHub before using vcpkg (which isn't all that clear, as it is not all that common)

If accepted, I am more than happy to PR this for every repo in the carbonengine namespace, as they all have this "problem". It is mostly about reducing friction when setting up any carbon repo.

###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.