### PR TITLE
chore: replace MSVC-style long/long long with fixed-width integer types

### DIFF
--- a/CCPAssert.cpp
+++ b/CCPAssert.cpp
@@ -52,7 +52,7 @@ public:
 		return m_result;
 	}
 
-    static unsigned long __stdcall MessageBoxThreadProc( void* p )
+    static uint32_t __stdcall MessageBoxThreadProc( void* p )
 	{
 		CCPAssertDialogThread* pThis = static_cast<CCPAssertDialogThread*>( p );
 

--- a/CCPLog.cpp
+++ b/CCPLog.cpp
@@ -127,7 +127,7 @@ bool IsLogging( LogType threshold )
 
 static CcpLogChannel_t s_logObject = { 1, "carbon-core", "Main", 0 };
 
-void LogToDebugger( CcpLogChannel_t& logObject, LogType type, unsigned long userData, const char* message )
+void LogToDebugger( CcpLogChannel_t& logObject, LogType type, uint32_t userData, const char* message )
 {
 #if defined( _WIN32 )
 	static const char* s_logType2string[ CCP::LOGTYPE_COUNT ] = { "[I] ", "[N] ", "[W] ", "[E] " };	
@@ -142,7 +142,7 @@ void LogToDebugger( CcpLogChannel_t& logObject, LogType type, unsigned long user
 #endif
 }
 
-CARBON_CORE_API void LogFuncChannel( CcpLogChannel_t& logObject, LogType type, unsigned long userData, CCPLOG_PRINTF_FORMAT const char* format, ... )
+CARBON_CORE_API void LogFuncChannel( CcpLogChannel_t& logObject, LogType type, uint32_t userData, CCPLOG_PRINTF_FORMAT const char* format, ... )
 {
 	va_list args;
 	va_start( args, format );
@@ -151,7 +151,7 @@ CARBON_CORE_API void LogFuncChannel( CcpLogChannel_t& logObject, LogType type, u
 }
 
 
-void LogFuncChannelRaw( CcpLogChannel_t& logObject, LogType type, unsigned long userData, const char* text )
+void LogFuncChannelRaw( CcpLogChannel_t& logObject, LogType type, uint32_t userData, const char* text )
 {
 	LogEchoList& callbacks = GetLogEchos( type );
 
@@ -187,7 +187,7 @@ void LogFuncChannelRaw( CcpLogChannel_t& logObject, LogType type, unsigned long 
 	}
 }
 
-CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type, unsigned long userData, const char* format, va_list args )
+CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type, uint32_t userData, const char* format, va_list args )
 {
 	if( !format )
 	{
@@ -240,7 +240,7 @@ CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type,
 #endif
 }
 
-void LogFunc( LogType type, unsigned long userData, CCPLOG_PRINTF_FORMAT const char* format, ... )
+void LogFunc( LogType type, uint32_t userData, CCPLOG_PRINTF_FORMAT const char* format, ... )
 {
 	va_list args;
 	va_start( args, format );
@@ -248,7 +248,7 @@ void LogFunc( LogType type, unsigned long userData, CCPLOG_PRINTF_FORMAT const c
 	va_end( args );
 }
 
-void LogFunc_v( LogType type, unsigned long userData, const char* format, va_list args )
+void LogFunc_v( LogType type, uint32_t userData, const char* format, va_list args )
 {
 	LogFuncChannel_v( s_logObject, type, userData, format, args );
 }

--- a/CcpTime.cpp
+++ b/CcpTime.cpp
@@ -206,13 +206,13 @@ CcpTime TimeNow()
 
 
 
-long TimeInMs( CcpTime time )
+int32_t TimeInMs( CcpTime time )
 {
 	time /= 10000;
 
 	CCP_ASSERT( time <= LONG_MAX );
 
-	return (long)time;
+	return (int32_t)time;
 }
 
 
@@ -262,7 +262,7 @@ CcpTime TimeFromDouble( double time )
 
 	return t;
 }
-CcpTime TimeFromMS( long time )
+CcpTime TimeFromMS( int32_t time )
 {
 	CcpTime t = ( CcpTime )( time * 10000 );
 	return t;

--- a/include/CCPLog.h
+++ b/include/CCPLog.h
@@ -32,11 +32,11 @@
 extern const char* g_moduleName;
 
 typedef short TLOGCHANNELID;
-typedef long TLOGSOURCEID;
+typedef int32_t TLOGSOURCEID;
 
 struct CcpLogChannel_t
 {
-	long oktocall;
+	int32_t oktocall;
 	const char *facility;
 	const char *object;
 	TLOGCHANNELID		channel;			// index into channel buffer
@@ -73,12 +73,12 @@ enum LogType
 CARBON_CORE_API uint32_t& GetLogCounter( CCP::LogType type );
 
 // Logs to a default channel
-CARBON_CORE_API void LogFunc( LogType type, unsigned long userData, CCPLOG_PRINTF_FORMAT const char* format, ... ) CCPLOG_PRINTF_FORMAT_ATTR( 3, 4 );
-CARBON_CORE_API void LogFunc_v( LogType type, unsigned long userData, const char* format, va_list args );
+CARBON_CORE_API void LogFunc( LogType type, uint32_t userData, CCPLOG_PRINTF_FORMAT const char* format, ... ) CCPLOG_PRINTF_FORMAT_ATTR( 3, 4 );
+CARBON_CORE_API void LogFunc_v( LogType type, uint32_t userData, const char* format, va_list args );
 
 // Logs to the given channel
-CARBON_CORE_API void LogFuncChannel( CcpLogChannel_t& logObject, LogType type, unsigned long userData, CCPLOG_PRINTF_FORMAT const char* format, ... ) CCPLOG_PRINTF_FORMAT_ATTR( 4, 5 );
-CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type, unsigned long userData, const char* format, va_list args );
+CARBON_CORE_API void LogFuncChannel( CcpLogChannel_t& logObject, LogType type, uint32_t userData, CCPLOG_PRINTF_FORMAT const char* format, ... ) CCPLOG_PRINTF_FORMAT_ATTR( 4, 5 );
+CARBON_CORE_API void LogFuncChannel_v( CcpLogChannel_t& logObject, LogType type, uint32_t userData, const char* format, va_list args );
 
 // Only logs from the same thread as this are allowed through, unless
 // the log functions is tagged as thread safe.
@@ -200,7 +200,7 @@ inline void ThrowLastError()
 	throw std::runtime_error( GetLastErrorMessage() );
 }
 
-typedef void (*LogEchoFunc)( CcpLogChannel_t& channel, LogType type, unsigned long userData, const char* message );
+typedef void (*LogEchoFunc)( CcpLogChannel_t& channel, LogType type, uint32_t userData, const char* message );
 
 // Register a log echo function. Future logging requests will be passed to this function. Note that
 // multiple log echo functions can be registered - this adds the function to a list, rather than replacing
@@ -217,7 +217,7 @@ CARBON_CORE_API void UnregisterLogEcho( LogEchoFunc cb );
 CARBON_CORE_API bool IsLogging( LogType threshold = LOGTYPE_INFO );
 
 // Let's offer a standard callback (for convenience) that can be registered:
-CARBON_CORE_API void LogToDebugger( CcpLogChannel_t& logObject, LogType type, unsigned long userData, const char* message );
+CARBON_CORE_API void LogToDebugger( CcpLogChannel_t& logObject, LogType type, uint32_t userData, const char* message );
 
 // Sets info type logs to be privileged and returns the previous value
 CARBON_CORE_API bool SetLogtypeInfoIsPrivileged(bool privileged);

--- a/include/CcpTime.h
+++ b/include/CcpTime.h
@@ -35,12 +35,12 @@ struct CcpDateTime
 };
 
 
-CARBON_CORE_API long TimeInMs( CcpTime time );
+CARBON_CORE_API int32_t TimeInMs( CcpTime time );
 CARBON_CORE_API double TimeAsDouble( CcpTime time );
 CARBON_CORE_API float TimeAsFloat( CcpTime time );
 CARBON_CORE_API bool TimeIsUTC( CcpTime time );
 CARBON_CORE_API CcpTime TimeFromDouble( double time );
-CARBON_CORE_API CcpTime TimeFromMS( long time );
+CARBON_CORE_API CcpTime TimeFromMS( int32_t time );
 
 CARBON_CORE_API bool TimeAsDateTime( CcpDateTime& dateTime, CcpTime time );
 CARBON_CORE_API bool TimeFromDateTime( CcpTime& timeStamp, const CcpDateTime& dateTime );

--- a/tests/CCPLog.cpp
+++ b/tests/CCPLog.cpp
@@ -8,14 +8,14 @@
 struct LogEntry
 {
 	CCP::LogType type;
-	unsigned long userData;
+	uint32_t userData;
 	char message[1024];
 };
 
 std::stack<LogEntry> logstack;
 
 
-void LogTracker( CcpLogChannel_t& logObject, CCP::LogType type, unsigned long userData, const char* message )
+void LogTracker( CcpLogChannel_t& logObject, CCP::LogType type, uint32_t userData, const char* message )
 {
 	LogEntry entry;
 	strncpy(entry.message, message, std::extent_v<decltype(entry.message)>);

--- a/tests/CcpMemory.cpp
+++ b/tests/CcpMemory.cpp
@@ -65,7 +65,7 @@ void TestAlignedRealloc()
 
 std::vector<std::pair<CCP::LogType, std::string>> s_logMessages;
 
-void LogCallback( CcpLogChannel_t& channel, CCP::LogType type, unsigned long userData, const char* message )
+void LogCallback( CcpLogChannel_t& channel, CCP::LogType type, uint32_t userData, const char* message )
 {
 	s_logMessages.push_back( std::make_pair( type, std::string( message ) ) );
 }


### PR DESCRIPTION
MSVC's long is 32-bit and long long is 64-bit, but long is 64-bit on LP64 platforms (Linux/macOS). Use uint32_t/int32_t/uint64_t/int64_t instead so widths are explicit and consistent across compilers.

---

I created this PR maybe more to start a conversation than to actually expect this to be accepted as-is. But when porting carbon to Linux, I ran into this in basically every repo.

The C++ standard only defines the minimum size of `long` being 32bit. And for some fun historical reasons, MSVC was like: "sure, so 32bit, right?". And GCC was like: "no, let's do 64bit!". And a big problem was born.

Now this problem doesn't surface as much when you primary work in MSVC: on Linux/MacOS it is just a bigger variable. The other way around however ....... it is much more problematic.

So generally what I tend to do and advise open source projects: as quickly as you can convert away from `long`, and use `cstdint` types (`uint32_t`, `int64_t`, ...) instead. This is unambiguous, and avoids "works on my machine" (and those are some nightmare debug sessions .....).
Now there are already `uint64_t` usages, but in some repos it is a mix. In `blue` for example there is a definition for `Unpack` with `uint64_t` [[1]](https://github.com/carbonengine/blue/blob/44ed19250e6beb0c8b864e41b6bf8ad1e230843b/include/BitPacker.h#L74), but the implementation is for `unsigned long long` [[2]](https://github.com/carbonengine/blue/blob/44ed19250e6beb0c8b864e41b6bf8ad1e230843b/include/BitPacker.h#L825). It is a bit confusing :D
(to make matters slightly worse, on Linux, `unsigned long long` and `uint64_t` are not considered the same type, despite them resolving to the same byte-size. Well, I guess you get my point by now: mixing these types is painful when not on MSVC).

Although `long` is the only real problem child: `short`, `unsigned char`, etc are other examples of poorly defined "minimum size" typing. It sometimes can be good to just "rip the bandaid", and convert them all to `cstdint` types. The additional benefit is that in that case you can enable a clang-tidy validator to ensure nobody adds them new again.
I have to admit: it always takes a bit of time to get used to no longer doing `short a`, but honestly: long term, it is 100% worth it, and makes for so much more readable/understandable code. Which means easier for other people to contribute, etc.

As example and further reading, Google also has it as part of their Style Guide: https://google.github.io/styleguide/cppguide.html#Integer_Types .

Anyway, these kind of changes are "patch killers", as they basically touch all the files, and any existing PR would require resolving after merging this. So some kind of planning and intention is warrant. If you decide to convert `short` / `unsigned char` too, it might be better to do that in one PR, instead of multiple. More than happy to update this PR to include the other types, and also not a problem to apply this to every repo of carbonengine. But let's first have the dialog whether this is wanted in the first place :)

Appreciate your time!

###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.