### PR TITLE
Update PR trigger rules from template

### DIFF
--- a/.teamcity/MacOS/Project.kt
+++ b/.teamcity/MacOS/Project.kt
@@ -152,7 +152,7 @@ class CarbonBuildMacOS(buildName: String, configType: String, preset: String, ag
                 authType = token {
                     token = "%GITHUB_CARBON_PAT%"
                 }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
             }
         }
         commitStatusPublisher {
@@ -187,5 +187,3 @@ class CarbonBuildMacOS(buildName: String, configType: String, preset: String, ag
         startsWith("teamcity.agent.jvm.os.arch", agentArchitecture)
     }
 })
-
-

--- a/.teamcity/Windows/Project.kt
+++ b/.teamcity/Windows/Project.kt
@@ -217,7 +217,7 @@ class CarbonBuildWindows(buildName: String, configType: String, preset: String, 
                 authType = token {
                     token = "%GITHUB_CARBON_PAT%"
                 }
-                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+                filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
             }
         }
         commitStatusPublisher {


### PR DESCRIPTION
Filtering PR builds by `MEMBER` had the side effect that those could not be built _at all_ on TeamCity.