### PR TITLE
Make public headers self-contained and stop relying on PCH

### DIFF
--- a/.teamcity/MacOS/Project.kt
+++ b/.teamcity/MacOS/Project.kt
@@ -30,6 +30,8 @@ val x64_Internal = CarbonBuildMacOS("Internal MacOS x64", "Internal", "x64-osx-i
 val x64_TrinityDev = CarbonBuildMacOS("TrinityDev MacOS x64", "TrinityDev", "x64-osx-trinitydev", "x86_64")
 val x64_Release = CarbonBuildMacOS("Release MacOS x64", "Release", "x64-osx-release", "x86_64")
 
+val arm64_NoPch = CarbonBuildMacOS("No PCH MacOS arm64", "Debug", "arm64-osx-debug", "aarch64", enablePch = false)
+
 object Project : Project({
     id("MacOS")
     name = "macOS"
@@ -45,13 +47,17 @@ object Project : Project({
     buildType(x64_Internal)
     buildType(x64_TrinityDev)
     buildType(x64_Release)
+
+    buildType(arm64_NoPch)
 })
 
-class CarbonBuildMacOS(buildName: String, configType: String, preset: String, agentArchitecture: String) : BuildType({
+class CarbonBuildMacOS(buildName: String, configType: String, preset: String, agentArchitecture: String, enablePch: Boolean = true) : BuildType({
     id(buildName.toId())
     name = buildName
 
-    artifactRules = "%env.CMAKE_INSTALL_PREFIX%"
+    if (enablePch) {
+        artifactRules = "%env.CMAKE_INSTALL_PREFIX%"
+    }
 
     params {
         param("env.SENTRY_CLI_DEBUG_SYMBOL_TYPE", "dsym")
@@ -104,34 +110,36 @@ class CarbonBuildMacOS(buildName: String, configType: String, preset: String, ag
         exec {
             name = "Configure"
             path = "cmake"
-            arguments = "--preset %env.CMAKE_PRESET% -S %teamcity.build.checkoutDir%/%github_checkout_folder% -B %env.CMAKE_BUILD_FOLDER% -DINSTALL_TO_MONOLITH=ON -DCMAKE_INSTALL_PREFIX=%env.CMAKE_INSTALL_PREFIX% -DVCPKG_INSTALL_OPTIONS=--x-buildtrees-root=%teamcity.build.checkoutDir%/%github_checkout_folder%/buildtrees"
+            arguments = "--preset %env.CMAKE_PRESET% -S %teamcity.build.checkoutDir%/%github_checkout_folder% -B %env.CMAKE_BUILD_FOLDER% -DINSTALL_TO_MONOLITH=ON -DCMAKE_INSTALL_PREFIX=%env.CMAKE_INSTALL_PREFIX% -DCCP_ENABLE_PCH=${if (enablePch) "ON" else "OFF"} -DVCPKG_INSTALL_OPTIONS=--x-buildtrees-root=%teamcity.build.checkoutDir%/%github_checkout_folder%/buildtrees"
         }
         exec {
             name = "Build"
             path = "cmake"
             arguments = "--build %env.CMAKE_BUILD_FOLDER% --config %env.CMAKE_CONFIG_TYPE% --target %env.CMAKE_BUILD_TARGETS%"
         }
-        exec {
-            name = "Run Tests"
-            workingDir = "%env.CMAKE_BUILD_FOLDER%"
-            path = "ctest"
-            arguments = "-C %env.CMAKE_CONFIG_TYPE% -V --output-on-failure --output-junit %env.CTEST_JUNIT_OUTPUT_FILE%"
-        }
-        exec {
-            name = "Package artifact"
-            path = "cmake"
-            arguments = "--install %env.CMAKE_BUILD_FOLDER% --config %env.CMAKE_CONFIG_TYPE%"
-        }
-        exec {
-            name = "Upload symbols to sentry"
-            path = "sentry-cli"
-            arguments = "upload-dif --wait %env.CMAKE_BUILD_FOLDER%"
-            param("script.content", """
-                #!/usr/bin/env bash -eu
-                filesWithSymbols = (
-                  # insert your binary files with symbols here!
-                )
-            """.trimIndent())
+        if (enablePch) {
+            exec {
+                name = "Run Tests"
+                workingDir = "%env.CMAKE_BUILD_FOLDER%"
+                path = "ctest"
+                arguments = "-C %env.CMAKE_CONFIG_TYPE% -V --output-on-failure --output-junit %env.CTEST_JUNIT_OUTPUT_FILE%"
+            }
+            exec {
+                name = "Package artifact"
+                path = "cmake"
+                arguments = "--install %env.CMAKE_BUILD_FOLDER% --config %env.CMAKE_CONFIG_TYPE%"
+            }
+            exec {
+                name = "Upload symbols to sentry"
+                path = "sentry-cli"
+                arguments = "upload-dif --wait %env.CMAKE_BUILD_FOLDER%"
+                param("script.content", """
+                    #!/usr/bin/env bash -eu
+                    filesWithSymbols = (
+                      # insert your binary files with symbols here!
+                    )
+                """.trimIndent())
+            }
         }
     }
 
@@ -163,10 +171,12 @@ class CarbonBuildMacOS(buildName: String, configType: String, preset: String, ag
                 }
             }
         }
-        xmlReport {
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = "+:%env.CMAKE_BUILD_FOLDER%/%env.CTEST_JUNIT_OUTPUT_FILE%"
-            verbose = true
+        if (enablePch) {
+            xmlReport {
+                reportType = XmlReport.XmlReportType.JUNIT
+                rules = "+:%env.CMAKE_BUILD_FOLDER%/%env.CTEST_JUNIT_OUTPUT_FILE%"
+                verbose = true
+            }
         }
         perfmon {
         }

--- a/.teamcity/Windows/Project.kt
+++ b/.teamcity/Windows/Project.kt
@@ -30,6 +30,8 @@ val Internal_v145 = CarbonBuildWindows("Internal Windows v145", "Internal", "x64
 val TrinityDev_v145 = CarbonBuildWindows("TrinityDev Windows v145", "TrinityDev", "x64-windows-v145-trinitydev", "-arch=x64 -vcvars_ver=14.51")
 val Release_v145 = CarbonBuildWindows("Release Windows v145", "Release", "x64-windows-v145-release", "-arch=x64 -vcvars_ver=14.51")
 
+val NoPch = CarbonBuildWindows("No PCH Windows", "Debug", "x64-windows-debug", enablePch = false)
+
 object Project : Project({
     id("Windows")
     name = "Windows"
@@ -43,14 +45,17 @@ object Project : Project({
     buildType(Internal_v145)
     buildType(TrinityDev_v145)
     buildType(Release_v145)
+
+    buildType(NoPch)
 })
 
-
-class CarbonBuildWindows(buildName: String, configType: String, preset: String, vsDevBatSwitches: String = "-arch=x64 -vcvars_ver=14.1") : BuildType({
+class CarbonBuildWindows(buildName: String, configType: String, preset: String, vsDevBatSwitches: String = "-arch=x64 -vcvars_ver=14.1", enablePch: Boolean = true) : BuildType({
     id(buildName.toId())
     this.name = buildName
 
-    artifactRules = "%env.CMAKE_INSTALL_PREFIX%"
+    if (enablePch) {
+        artifactRules = "%env.CMAKE_INSTALL_PREFIX%"
+    }
 
     params {
         param("env.GIT_TAG_HASH_OVERRIDE", "")
@@ -108,94 +113,96 @@ class CarbonBuildWindows(buildName: String, configType: String, preset: String, 
         exec {
             name = "Configure"
             path = "cmake"
-            arguments = "--preset %env.CMAKE_PRESET% -S %teamcity.build.checkoutDir%/%github_checkout_folder% -B %env.CMAKE_BUILD_FOLDER% -DINSTALL_TO_MONOLITH=ON -DCMAKE_INSTALL_PREFIX=%env.CMAKE_INSTALL_PREFIX% -DVCPKG_INSTALL_OPTIONS=--x-buildtrees-root=%teamcity.build.checkoutDir%/%github_checkout_folder%/buildtrees"
+            arguments = "--preset %env.CMAKE_PRESET% -S %teamcity.build.checkoutDir%/%github_checkout_folder% -B %env.CMAKE_BUILD_FOLDER% -DINSTALL_TO_MONOLITH=ON -DCMAKE_INSTALL_PREFIX=%env.CMAKE_INSTALL_PREFIX% -DCCP_ENABLE_PCH=${if (enablePch) "ON" else "OFF"} -DVCPKG_INSTALL_OPTIONS=--x-buildtrees-root=%teamcity.build.checkoutDir%/%github_checkout_folder%/buildtrees"
         }
         exec {
             name = "Build"
             path = "cmake"
             arguments = "--build %env.CMAKE_BUILD_FOLDER% --config %env.CMAKE_CONFIG_TYPE% --target %env.CMAKE_BUILD_TARGETS%"
         }
-        exec {
-            name = "Run Tests"
-            workingDir = "%env.CMAKE_BUILD_FOLDER%"
-            path = "ctest"
-            arguments = "-C %env.CMAKE_CONFIG_TYPE% -V --output-on-failure --output-junit %env.CTEST_JUNIT_OUTPUT_FILE%"
-        }
-        exec {
-            name = "Package artifact"
-            path = "cmake"
-            arguments = "--install %env.CMAKE_BUILD_FOLDER% --config %env.CMAKE_CONFIG_TYPE%"
-        }
-        exec {
-            name = "Upload symbols to sentry"
-            path = "sentry-cli"
-            arguments = "upload-dif --wait %env.CMAKE_BUILD_FOLDER%"
-            param("script.content", """
-                #!/usr/bin/env bash -eu
-                filesWithSymbols = (
-                  # insert your binary files with symbols here!
-                )
-            """.trimIndent())
-        }
-        script {
-            name = "(Windows) CMD Upload debug symbols to internal symbol server"
-            scriptContent = """
-                @echo off
-                (
-                echo ${'$'}User = "%DOMAIN_USER%"
-                echo ${'$'}Password = ConvertTo-SecureString -String "%DOMAIN_USER_PASSWORD%" -AsPlainText -Force
-                echo ${'$'}Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ${'$'}User, ${'$'}Password
-                echo New-PSDrive -Name "symbols" -PSProvider FileSystem -Root ${'$'}Env:TC_SYMBOL_STORE_PATH -Credential ${'$'}Credential
-                echo Write-Host "##teamcity[progressMessage 'Storing symbols']"
-                echo ${'$'}symstoreFlags = ^@^("add","/compress","/t", "CCP Games", "/c", "TeamCity %build.number%", "/s", "${'$'}Env:TC_SYMBOL_STORE_PATH", "/o", "/r",  "/f", "%env.CMAKE_BUILD_FOLDER%"^) 
-                echo ^& ${'$'}Env:TC_SYMSTORE_PATH ${'$'}symstoreFlags ^| Tee-Object -file symstore.txt
-                echo ${'$'}stored = get-content symstore.txt ^| Select-String "^SYMSTORE: Number of files stored = (.*)${'$'}"
-                echo ${'$'}stored = ${'$'}stored.Matches.Groups[1].Value
-                echo ${'$'}errors = get-content symstore.txt ^| Select-String "^SYMSTORE: Number of errors = (.*)${'$'}"
-                echo ${'$'}errors = ${'$'}errors.Matches.Groups[1].Value
-                echo ${'$'}ignored = get-content symstore.txt ^| Select-String "^SYMSTORE: Number of files ignored = (.*)${'$'}"
-                echo ${'$'}ignored = ${'$'}ignored.Matches.Groups[1].Value
-                echo Write-Host "##teamcity[buildStatus text='Stored: ${'$'}stored, Errors: ${'$'}errors, Ignored: ${'$'}ignored']"
-                ) > file.ps1
-                powershell -File file.ps1
-            """.trimIndent()
-        }
-        powerShell {
-            name = "(Windows) Upload debug symbols to internal symbol server"
-            enabled = false
-
-            conditions {
-                startsWith("teamcity.agent.jvm.os.name", "Windows")
+        if (enablePch) {
+            exec {
+                name = "Run Tests"
+                workingDir = "%env.CMAKE_BUILD_FOLDER%"
+                path = "ctest"
+                arguments = "-C %env.CMAKE_CONFIG_TYPE% -V --output-on-failure --output-junit %env.CTEST_JUNIT_OUTPUT_FILE%"
             }
-            scriptMode = script {
-                content = """
-                    ${'$'}User = "%DOMAIN_USER%"
-                    ${'$'}Password = ConvertTo-SecureString -String "%DOMAIN_USER_PASSWORD%" -AsPlainText -Force
-                    ${'$'}Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ${'$'}User, ${'$'}Password
-                    New-PSDrive -Name "symbols" -PSProvider FileSystem -Root ${'$'}Env:TC_SYMBOL_STORE_PATH -Credential ${'$'}Credential
-                    
-                    Write-Host "##teamcity[progressMessage 'Storing symbols']"
-                    ${'$'}symstoreFlags = @("add",
-                                     "/compress",
-                                     "/t", "CCP Games", # Product Name
-                                     "/c", "TeamCity %build.number%", #Comment
-                                     "/s", "${'$'}Env:TC_SYMBOL_STORE_PATH", # Store destination
-                                     "/o", # Verbose
-                                     "/r", # Recursive
-                                     "/f", "%env.CMAKE_BUILD_FOLDER%") # source folder
-                    & ${'$'}Env:TC_SYMSTORE_PATH ${'$'}symstoreFlags | Tee-Object -file symstore.txt
-                    
-                    ${'$'}stored = get-content symstore.txt | Select-String "^SYMSTORE: Number of files stored = (.*)${'$'}"
-                    ${'$'}stored = ${'$'}stored.Matches.Groups[1].Value
-                    
-                    ${'$'}errors = get-content symstore.txt | Select-String "^SYMSTORE: Number of errors = (.*)${'$'}"
-                    ${'$'}errors = ${'$'}errors.Matches.Groups[1].Value
-                    
-                    ${'$'}ignored = get-content symstore.txt | Select-String "^SYMSTORE: Number of files ignored = (.*)${'$'}"
-                    ${'$'}ignored = ${'$'}ignored.Matches.Groups[1].Value
-                    
-                    Write-Host "##teamcity[buildStatus text='Stored: ${'$'}stored, Errors: ${'$'}errors, Ignored: ${'$'}ignored']"
+            exec {
+                name = "Package artifact"
+                path = "cmake"
+                arguments = "--install %env.CMAKE_BUILD_FOLDER% --config %env.CMAKE_CONFIG_TYPE%"
+            }
+            exec {
+                name = "Upload symbols to sentry"
+                path = "sentry-cli"
+                arguments = "upload-dif --wait %env.CMAKE_BUILD_FOLDER%"
+                param("script.content", """
+                    #!/usr/bin/env bash -eu
+                    filesWithSymbols = (
+                      # insert your binary files with symbols here!
+                    )
+                """.trimIndent())
+            }
+            script {
+                name = "(Windows) CMD Upload debug symbols to internal symbol server"
+                scriptContent = """
+                    @echo off
+                    (
+                    echo ${'$'}User = "%DOMAIN_USER%"
+                    echo ${'$'}Password = ConvertTo-SecureString -String "%DOMAIN_USER_PASSWORD%" -AsPlainText -Force
+                    echo ${'$'}Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ${'$'}User, ${'$'}Password
+                    echo New-PSDrive -Name "symbols" -PSProvider FileSystem -Root ${'$'}Env:TC_SYMBOL_STORE_PATH -Credential ${'$'}Credential
+                    echo Write-Host "##teamcity[progressMessage 'Storing symbols']"
+                    echo ${'$'}symstoreFlags = ^@^("add","/compress","/t", "CCP Games", "/c", "TeamCity %build.number%", "/s", "${'$'}Env:TC_SYMBOL_STORE_PATH", "/o", "/r",  "/f", "%env.CMAKE_BUILD_FOLDER%"^)
+                    echo ^& ${'$'}Env:TC_SYMSTORE_PATH ${'$'}symstoreFlags ^| Tee-Object -file symstore.txt
+                    echo ${'$'}stored = get-content symstore.txt ^| Select-String "^SYMSTORE: Number of files stored = (.*)${'$'}"
+                    echo ${'$'}stored = ${'$'}stored.Matches.Groups[1].Value
+                    echo ${'$'}errors = get-content symstore.txt ^| Select-String "^SYMSTORE: Number of errors = (.*)${'$'}"
+                    echo ${'$'}errors = ${'$'}errors.Matches.Groups[1].Value
+                    echo ${'$'}ignored = get-content symstore.txt ^| Select-String "^SYMSTORE: Number of files ignored = (.*)${'$'}"
+                    echo ${'$'}ignored = ${'$'}ignored.Matches.Groups[1].Value
+                    echo Write-Host "##teamcity[buildStatus text='Stored: ${'$'}stored, Errors: ${'$'}errors, Ignored: ${'$'}ignored']"
+                    ) > file.ps1
+                    powershell -File file.ps1
                 """.trimIndent()
+            }
+            powerShell {
+                name = "(Windows) Upload debug symbols to internal symbol server"
+                enabled = false
+
+                conditions {
+                    startsWith("teamcity.agent.jvm.os.name", "Windows")
+                }
+                scriptMode = script {
+                    content = """
+                        ${'$'}User = "%DOMAIN_USER%"
+                        ${'$'}Password = ConvertTo-SecureString -String "%DOMAIN_USER_PASSWORD%" -AsPlainText -Force
+                        ${'$'}Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList ${'$'}User, ${'$'}Password
+                        New-PSDrive -Name "symbols" -PSProvider FileSystem -Root ${'$'}Env:TC_SYMBOL_STORE_PATH -Credential ${'$'}Credential
+
+                        Write-Host "##teamcity[progressMessage 'Storing symbols']"
+                        ${'$'}symstoreFlags = @("add",
+                                         "/compress",
+                                         "/t", "CCP Games", # Product Name
+                                         "/c", "TeamCity %build.number%", #Comment
+                                         "/s", "${'$'}Env:TC_SYMBOL_STORE_PATH", # Store destination
+                                         "/o", # Verbose
+                                         "/r", # Recursive
+                                         "/f", "%env.CMAKE_BUILD_FOLDER%") # source folder
+                        & ${'$'}Env:TC_SYMSTORE_PATH ${'$'}symstoreFlags | Tee-Object -file symstore.txt
+
+                        ${'$'}stored = get-content symstore.txt | Select-String "^SYMSTORE: Number of files stored = (.*)${'$'}"
+                        ${'$'}stored = ${'$'}stored.Matches.Groups[1].Value
+
+                        ${'$'}errors = get-content symstore.txt | Select-String "^SYMSTORE: Number of errors = (.*)${'$'}"
+                        ${'$'}errors = ${'$'}errors.Matches.Groups[1].Value
+
+                        ${'$'}ignored = get-content symstore.txt | Select-String "^SYMSTORE: Number of files ignored = (.*)${'$'}"
+                        ${'$'}ignored = ${'$'}ignored.Matches.Groups[1].Value
+
+                        Write-Host "##teamcity[buildStatus text='Stored: ${'$'}stored, Errors: ${'$'}errors, Ignored: ${'$'}ignored']"
+                    """.trimIndent()
+                }
             }
         }
     }
@@ -228,10 +235,12 @@ class CarbonBuildWindows(buildName: String, configType: String, preset: String, 
                 }
             }
         }
-        xmlReport {
-            reportType = XmlReport.XmlReportType.JUNIT
-            rules = "+:%env.CMAKE_BUILD_FOLDER%/%env.CTEST_JUNIT_OUTPUT_FILE%"
-            verbose = true
+        if (enablePch) {
+            xmlReport {
+                reportType = XmlReport.XmlReportType.JUNIT
+                rules = "+:%env.CMAKE_BUILD_FOLDER%/%env.CTEST_JUNIT_OUTPUT_FILE%"
+                verbose = true
+            }
         }
         perfmon {
         }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,46 @@ set(PUBLIC_HEADER_FILES
 )
 target_sources(CcpCore PRIVATE ${PUBLIC_HEADER_FILES})
 
-target_precompile_headers(CcpCore PRIVATE StdAfx.h)
+# The precompiled header is a build-speed optimisation, not a way to hand
+# declarations to every translation unit. Building with -DCCP_ENABLE_PCH=OFF
+# proves that each source and header still works without PCH.
+option(CCP_ENABLE_PCH "Use a precompiled header to speed up compilation." ON)
+
+if(CCP_ENABLE_PCH)
+    target_precompile_headers(CcpCore PRIVATE StdAfx.h)
+endif()
+
+# Every public header must compile on its own, without the PCH and without any
+# other header having been included first. Consumers of the installed package get
+# no PCH, so a header that only compiles behind one is already broken for them.
+#
+# Each header gets a generated translation unit that includes it twice, to also
+# ensure "#pragma once" is applied correctly.
+option(CCP_BUILD_HEADER_SELFTEST "Verify that every public header is self-contained." ON)
+
+if(CCP_BUILD_HEADER_SELFTEST)
+    set(HEADER_SELFTEST_SOURCES "")
+    foreach(_header IN LISTS PUBLIC_HEADER_FILES)
+        get_filename_component(_header_abs "${_header}" ABSOLUTE)
+        get_filename_component(_header_name "${_header}" NAME_WE)
+        set(_selftest_source "${CMAKE_CURRENT_BINARY_DIR}/header_selftest/${_header_name}_selftest.cpp")
+        file(GENERATE
+                OUTPUT "${_selftest_source}"
+                CONTENT "#include \"${_header_abs}\"\n#include \"${_header_abs}\"\n"
+        )
+        list(APPEND HEADER_SELFTEST_SOURCES "${_selftest_source}")
+    endforeach()
+
+    add_library(CcpCoreHeaderSelftest OBJECT ${HEADER_SELFTEST_SOURCES})
+    target_include_directories(CcpCoreHeaderSelftest PRIVATE
+            $<TARGET_PROPERTY:CcpCore,INTERFACE_INCLUDE_DIRECTORIES>
+            ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    target_compile_definitions(CcpCoreHeaderSelftest PRIVATE
+            $<TARGET_PROPERTY:CcpCore,INTERFACE_COMPILE_DEFINITIONS>
+    )
+    set_target_properties(CcpCoreHeaderSelftest PROPERTIES DISABLE_PRECOMPILE_HEADERS ON)
+endif()
 
 if(APPLE)
     set_prefix_and_suffix(CcpCore)

--- a/CcpAssert.cpp
+++ b/CcpAssert.cpp
@@ -4,6 +4,7 @@
 #include "include/CcpSecureCrt.h"
 
 #ifdef _WIN32
+	#include <windows.h>
 	#include <winuser.h>
 #endif
 

--- a/CcpCallstack.cpp
+++ b/CcpCallstack.cpp
@@ -2,6 +2,8 @@
 
 #include "include/CcpCallstack.h"
 
+#include <cstring>
+
 namespace
 {
     
@@ -25,6 +27,8 @@ NB: VS2017 warns about the use of an ill-formed typedef in the <dbghelp.h> file,
     but that's how it ships inside "Windows Kits\8.1" so guess we're stuck with it. 
 	We can, at least, mute the warning...
 */
+#include <windows.h>
+
 #pragma warning(push)
 #pragma warning(disable:4091)
 #include <dbghelp.h>

--- a/CcpDefines.cpp
+++ b/CcpDefines.cpp
@@ -4,6 +4,8 @@
 #include "include/CcpDefines.h"
 #include "include/CcpMacros.h"
 
+#include <cstddef>
+
 const char* CcpGetPlatformToolset()
 {
 	return CCP_STRINGIZE( PLATFORM_TOOLSET );

--- a/CcpFileUtils.cpp
+++ b/CcpFileUtils.cpp
@@ -4,8 +4,11 @@
 #include "include/CcpFileUtils.h"
 #include "include/StringConversions.h"
 #include "include/CcpSecureCrt.h"
+#include "include/CcpLog.h"
 
+#include <algorithm>
 #include <stdlib.h>
+#include <vector>
 
 #ifdef _WIN32
 

--- a/CcpHash.cpp
+++ b/CcpHash.cpp
@@ -2,6 +2,8 @@
 
 #include "include/CcpHash.h"
 
+#include <cstdint>
+
 /// See http://www.isthe.com/chongo/tech/comp/fnv/ for a description of the FNV1 hash algorithm
 /// and the specific values used here.
 

--- a/CcpLog.cpp
+++ b/CcpLog.cpp
@@ -3,6 +3,7 @@
 #include "CcpLog.h"
 
 #include <cassert>
+#include <cstring>
 #include <thread>
 #include <vector>
 

--- a/CcpMemory.cpp
+++ b/CcpMemory.cpp
@@ -5,6 +5,7 @@
 #include "include/CcpAssert.h"
 #include "include/CcpSecureCrt.h"
 #include "include/CcpTelemetry.h"
+#include "include/CcpLog.h"
 #include "CcpMemoryTrackerMutex.h"
 
 #ifdef __APPLE__
@@ -321,6 +322,8 @@ static inline void CcpPlatformFree( void* p )
 }
 
 #else
+
+#include <atomic>
 
 std::atomic<size_t> s_memuse( 0 );
 

--- a/CcpMemoryTracker.cpp
+++ b/CcpMemoryTracker.cpp
@@ -6,6 +6,7 @@
 #include "include/CcpMemory.h"
 #include "include/CcpMutex.h"
 
+#include <algorithm>
 #include <map>
 
 // #define CCP_UNIT_TEST 1
@@ -15,6 +16,7 @@
 #include "include/CcpHash.h"
 #include "include/CcpCallstack.h"
 #include "include/CcpSecureCrt.h"
+#include "include/CcpLog.h"
 
 #ifdef _WIN32
 	#include <Psapi.h>

--- a/CcpStatistics.cpp
+++ b/CcpStatistics.cpp
@@ -2,6 +2,9 @@
 
 #include "include/CcpStatistics.h"
 
+#include <algorithm>
+#include <cmath>
+
 #include "CcpTelemetry.h"
 
 #if CCP_TELEMETRY_ENABLED

--- a/CcpTelemetry.cpp
+++ b/CcpTelemetry.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2013 CCP ehf.
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cctype>
@@ -9,6 +10,7 @@
 
 #include "include/CcpAssert.h"
 #include "include/CcpMutex.h"
+#include "include/CcpLog.h"
 #include "include/CcpTelemetry.h"
 #include "include/CcpTime.h"
 

--- a/CcpTime.cpp
+++ b/CcpTime.cpp
@@ -3,6 +3,7 @@
 #include "include/CcpTime.h"
 #include "include/CcpAssert.h"
 #include <cfloat>
+#include <climits>
 #include <cmath>
 
 #ifdef _WIN32
@@ -112,6 +113,7 @@ uint64_t CcpGetTickCount()
 
 #else
 
+#include <sys/time.h>
 #include <time.h>
 
 uint64_t CcpGetTimestamp()

--- a/include/CachedAllocator.h
+++ b/include/CachedAllocator.h
@@ -4,6 +4,8 @@
 #ifndef CachedAllocator_h
 #define CachedAllocator_h
 
+#include <cstdint>
+
 #include "CcpMemory.h"
 
 // CachedAllocator is a template class that provides cached allocations for its template argument.

--- a/include/CcpCallstack.h
+++ b/include/CcpCallstack.h
@@ -3,6 +3,9 @@
 #ifndef _CCPCALLSTACK_H_
 #define _CCPCALLSTACK_H_
 
+#include <cstddef>
+#include <cstdio>
+
 #include "carbon_core_export.h"
 
 class CARBON_CORE_API CCPCallstack

--- a/include/CcpHash.h
+++ b/include/CcpHash.h
@@ -5,6 +5,8 @@
 #ifndef _CCPHASH_H_
 #define _CCPHASH_H_
 
+#include <cstddef>
+
 #include "carbon_core_export.h"
 
 /// See http://www.isthe.com/chongo/tech/comp/fnv/ for a description of the FNV1 hash algorithm.

--- a/include/CcpLog.h
+++ b/include/CcpLog.h
@@ -5,6 +5,7 @@
 #define CCP_LOG_H
 
 #include <cstdarg>
+#include <cstdint>
 #include <stdexcept>
 #include "carbon_core_export.h"
 

--- a/include/CcpMemoryTracker.h
+++ b/include/CcpMemoryTracker.h
@@ -27,6 +27,8 @@ CARBON_CORE_API bool IsCallstackCaptureEnabled();
 CARBON_CORE_API void MemoryTrackerSummaryReportToFile( FILE* file );
 
 #ifdef _WIN32
+#include <windows.h>
+
 CARBON_CORE_API size_t GetHeapSizeWithHeapWalk( HANDLE heap );
 CARBON_CORE_API HANDLE MemoryTrackerGetHeapForTracking();
 #endif

--- a/include/CcpPairingHeap.h
+++ b/include/CcpPairingHeap.h
@@ -31,6 +31,8 @@
 
 #include <vector>
 
+#include "CcpAssert.h"
+
 
 //Declarations
 

--- a/include/CcpSecureCrt.h
+++ b/include/CcpSecureCrt.h
@@ -4,10 +4,15 @@
 #ifndef CcpSecureCrt_h
 #define CcpSecureCrt_h
 
+#include <cstdarg>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <cwchar>
+
 #ifndef _MSC_VER
 
-#include <cstdarg>
-#include <ctime>
 #include <algorithm>
 
 #include "carbon_core_export.h"

--- a/include/CcpThread.h
+++ b/include/CcpThread.h
@@ -21,6 +21,7 @@
 		_mm_pause();
 	}
 #elif __APPLE__
+	#include <mach/port.h>
 	#include <pthread.h>
 	#include <sched.h>
     typedef mach_port_t CcpThreadId_t;

--- a/include/ICcpStream.h
+++ b/include/ICcpStream.h
@@ -4,6 +4,7 @@
 #ifndef ICcpStream_H
 #define ICcpStream_H
 
+#include <cstddef>
 
 struct ICcpStream
 {

--- a/include/TrackableContainer.h
+++ b/include/TrackableContainer.h
@@ -5,11 +5,10 @@
 #ifndef TRACKABLECONTAINER_H
 #define TRACKABLECONTAINER_H
 
+#include <memory>
+
 #include "CcpMemory.h"
 #include "CcpSecureCrt.h"
-#ifdef _MSC_VER
-	#include <xmemory>
-#endif
 
 template<class T>
 class NamedStdAllocator : public std::allocator<T> {


### PR DESCRIPTION
## Summary

Initially I wanted to make an issue first, to talk this over. But code speaks louder than any words, so I ended up making this PR instead. But this PR is much more a "do you want to go in this direction?" question that should have been asked in an issue.
Sorry :(

When compiling this (and many of the other carbon) repositories on Linux, you run into the issue that a bunch of include headers are missing. And this totally make sense, as these repositories use PCH with `<windows.h>`. Which means on Windows, a ton of system headers are added without people realizing (as `windows.h` is a terrible header in this regard).

Building on MacOS will tell about most: but not all. And this is because GCC has a different opinion about system headers than others do: it minimizes them as much as it can. Famously, [since GCC 13 they removed the inclusion of `cstdint` by their headers](https://gcc.gnu.org/gcc-13/porting_to.html#header-dep-changes). To take this as example, it means:
- On Windows, `<windows.h>` will transitively include this header.
- On MacOS, the fact you use libc++ will transitively include this header (for now at least).
- On Linux/GCC: it will not.

So we run into compiler-errors on Linux. Fixing this can be done in several ways, but it also highlights a bigger problem: something that works on one platform, fails on another. And those can be annoying to deal with after-the-fact.

While delving into this further, I noticed a bit of a more tricky problem to deal with:

No file in the "include" folder includes `StdAfx.h`, but some do depend on its context via PCH. This means there is a knock-on effect through all repositories that depend on `core`: they all need a PCH to at least cover the include files in the PCH of `core`. And that can be unexpected.

So this PR sets out to fix these issues:
- Make public headers self-contained (and validate that with a self-test)
- Make this repository build without PCH

Additionally, I let Claude write some code for the CI, so it covers that non-PCH keeps on building. Just to prevent regression on this front.

After this PR you end up with public-headers that don't implicitly need a PCH to contain some includes. In other words: this fixes that silently the `StdAfx.h` leaked into the public headers, although `StdAfx.h` itself wasn't made public. This also means that after this PR PCH becomes a compile-performance optimization again, and not a dependency of its own.

That all said and done, the actual requirement to build on Linux is a much smaller change: https://github.com/carbonengine/core/compare/main...TrueBrain:carbonengine-core:push-xkzzrvtkskxx?expand=1. I am also fine if that is the route to take.

PS: of course if this PR is accepted, I can do the same work on other repositories that have the same issue. About 50% of them currently fail on missing headers, in different degrees.
PPS: the no-PCH build most likely fails on MacOS till https://github.com/carbonengine/core/pull/41 lands.

<!-- One or two sentences: what does this PR do, and why? -->

## AI assistance disclosure

<!-- Did AI tools generate or significantly assist any part of this PR (code,
tests, commit messages, this description)? If so, briefly say what and how.
Write "None" if not. Be honest: disclosure isn't held against you. What gets a
PR closed is unverified output you can't stand behind, not the use of AI. -->

Claude wrote the code; I instructed what I wanted to achieve. Verified it is matching up with my expectations.

## Type of change

<!-- Tick all that apply. -->

- [x] Bug fix
- [ ] New feature
- [x] Refactor / cleanup (no behaviour change)
- [ ] Documentation
- [x] Build, CI, or tooling
- [ ] Breaking change (public API or ABI)
- [ ] Other (describe below)

## Linked issue (optional)

<!-- e.g. "Closes #123" or "Refs #456". Leave blank if this PR stands on its own. -->

## What changed

<!-- Short bullets. Aim for the diff-summary you'd want as a reviewer. -->

- Ensure public headers are including all files they depend on
- Ensure Linux doesn't fail on missing headers (it will still fail on other issues; but that is for other PRs)
- Ensure CI prevents regression

## Testing

<!-- What did you run locally? Paste the command if it's useful. New tests added? -->

- Build with PCH on Linux and Windows
- Build without PCH on Linux and Windows

## Platforms tested

<!-- Tick what applies. Leave blank if not relevant (e.g. a Python-only or docs change). -->

- [x] Windows
- [ ] macOS
- [x] Linux

## Screenshots / captures

<!-- Only if your change has a visual effect. Drag & drop images here. -->

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/carbonengine/.github/blob/main/CONTRIBUTING.md).
- [x] My commits follow the commit-message style described there.
- [x] I've added or updated tests where it made sense.
- [x] I've updated docs / inline API comments for any behaviour change.
- [x] My CLA / ICLA is signed (the bot will let you know if it isn't).

---

<!--
Heads-up: builds run on our internal CI, not GitHub Actions. On all repos a
maintainer triggers the build after an initial review. Results appear as commit status checks. If you don't see activity
within a few working days, comment on the PR (the maintainers are subscribed), or
@-mention the maintainers team shown in its reviewers.
-->

###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.