### PR TITLE
Enable vcpkg manifest features based on CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,33 @@
 
 cmake_minimum_required(VERSION 3.19)
 
+option(WITH_TELEMETRY "Enable profiler integration" ON)
+option(WITH_MEMORY_TRACKING "Enable tracking of memory allocations." ON)
+option(BUILD_TESTING "Build and run tests. Enabled by default." ON)
+
+# Determine if/when to generate/build documentation. The rules are as follows:
+# - If running locally - Build documentation is OFF by default
+# - If running on a build agent (TeamCity) - Build documentation is ON by default
+# - If -DBUILD_DOCUMENTATION=ON/OFF flag is explicitly set, use it.
+set(BUILD_DOCUMENTATION_DEFAULT_FLAG OFF)
+if(DEFINED ENV{TEAMCITY_VERSION})
+    set(BUILD_DOCUMENTATION_DEFAULT_FLAG ON)
+endif()
+option(BUILD_DOCUMENTATION "Build Documentation" ${BUILD_DOCUMENTATION_DEFAULT_FLAG})
+
+if(WITH_TELEMETRY)
+    list(APPEND VCPKG_MANIFEST_FEATURES "telemetry")
+endif()
+if(WITH_MEMORY_TRACKING)
+    list(APPEND VCPKG_MANIFEST_FEATURES "memory-tracking")
+endif()
+if(BUILD_TESTING)
+    list(APPEND VCPKG_MANIFEST_FEATURES "tests")
+endif()
+if(BUILD_DOCUMENTATION)
+    list(APPEND VCPKG_MANIFEST_FEATURES "docs")
+endif()
+
 project(CcpCore)
 
 set(CCP_TOOLSET ${CMAKE_GENERATOR_TOOLSET})
@@ -12,9 +39,6 @@ include(cmake/CcpTargetConfigurations.cmake)
 include(cmake/CcpDocsGenerator.cmake)
 include(cmake/CcpPackageConfigHelpers.cmake)
 include(cmake/CcpBuildConfigurations.cmake)
-
-option(WITH_TELEMETRY "Enable profiler integration" ON)
-option(WITH_MEMORY_TRACKING "Enable tracking of memory allocations." ON)
 
 set(SRC_FILES
         CcpCore.cpp
@@ -127,12 +151,9 @@ else()
     target_compile_definitions(CcpCore PUBLIC CCP_MEMORY_DEBUG=0)
 endif()
 
-if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    option(BUILD_TESTING "Build and run tests. Enabled by default." ON)
+if(BUILD_TESTING)
     include(CTest)
-    if(BUILD_TESTING)
-        add_subdirectory(tests)
-    endif()
+    add_subdirectory(tests)
 endif()
 
 target_compile_definitions(CcpCore PRIVATE PLATFORM_TOOLSET=${CCP_TOOLSET})
@@ -152,56 +173,45 @@ target_include_directories(CcpCore
         ${CMAKE_CURRENT_BINARY_DIR}
 )
 
+if(BUILD_DOCUMENTATION)
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    include(cmake/CcpDocsGenerator.cmake)
+
+    if(WIN32)
+        set(PYTHONPATH_ENV_SPHINX "$<TARGET_FILE_DIR:CcpCore>\;${CMAKE_SOURCE_DIR}/python")
+    elseif(APPLE)
+        set(PYTHONPATH_ENV_SPHINX "$<TARGET_FILE_DIR:CcpCore>:${CMAKE_SOURCE_DIR}/python")
+    endif()
+
+    set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/doc/source)
+    set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/doc/build)
+
+    get_target_property(CORE_COMPILE_DEFINITIONS CcpCore COMPILE_DEFINITIONS)
+    list(TRANSFORM CORE_COMPILE_DEFINITIONS GENEX_STRIP)
+    list(APPEND CORE_COMPILE_DEFINITIONS
+            CARBON_CORE_API=
+            CARBON_CORE_DEPRECATED_EXPORT=
+            NOINLINE=
+            CCPLOG_PRINTF_FORMAT=
+    )
+    list(JOIN CORE_COMPILE_DEFINITIONS " \\\n" CORE_COMPILE_DEFINITIONS)
+
+    create_carbon_docs_sphinx_target(
+        PYTHON_EXE ${Python3_EXECUTABLE}
+        VENV_NAME docs_generation_venv
+        PYTHONPATH_ENV ${PYTHONPATH_ENV_SPHINX}
+        SPHINX_SOURCE ${SPHINX_SOURCE}
+        SPHINX_BUILD ${SPHINX_BUILD}
+        DOXYGEN_SRC_FILES ${SRC_FILES}
+        SPHINX_TARGET_NAME Sphinx
+        DOXYGEN_TARGET_NAME Doxygen
+        INSTALL_DESTINATION documentation/carbon-core
+        EXTRA_COMPILE_DEFINITIONS ${CORE_COMPILE_DEFINITIONS}
+    )
+endif()
+
 # Provide an install target iff this is the top level project only
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
-    # Determine if/when to generate/build documentation. The rules are as follows:
-    # - If running locally - Build documentation is OFF by default
-    # - If running on a build agent (TeamCity) - Build documentation is ON by default
-    # - If -DBUILD_DOCUMENTATION=ON/OFF flag is explicitly set, use it.
-    set(BUILD_DOCUMENTATION_DEFAULT_FLAG OFF)
-    if(DEFINED ENV{TEAMCITY_VERSION})
-        set(BUILD_DOCUMENTATION_DEFAULT_FLAG ON)
-    endif()
-    message(STATUS "Document generation settings: default=${BUILD_DOCUMENTATION_DEFAULT_FLAG}, option BUILD_DOCUMENTATION=${BUILD_DOCUMENTATION}")
-    option(BUILD_DOCUMENTATION "Build Documentation" ${BUILD_DOCUMENTATION_DEFAULT_FLAG})
-
-    if(BUILD_DOCUMENTATION)
-        find_package(Python3 COMPONENTS Interpreter REQUIRED)
-        include(cmake/CcpDocsGenerator.cmake)
-
-        if(WIN32)
-            set(PYTHONPATH_ENV_SPHINX "$<TARGET_FILE_DIR:CcpCore>\;${CMAKE_SOURCE_DIR}/python")
-        elseif(APPLE)
-            set(PYTHONPATH_ENV_SPHINX "$<TARGET_FILE_DIR:CcpCore>:${CMAKE_SOURCE_DIR}/python")
-        endif()
-
-        set(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/doc/source)
-        set(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/doc/build)
-
-        get_target_property(CORE_COMPILE_DEFINITIONS CcpCore COMPILE_DEFINITIONS)
-        list(TRANSFORM CORE_COMPILE_DEFINITIONS GENEX_STRIP)
-        list(APPEND CORE_COMPILE_DEFINITIONS
-                CARBON_CORE_API=
-                CARBON_CORE_DEPRECATED_EXPORT=
-                NOINLINE=
-                CCPLOG_PRINTF_FORMAT=
-        )
-        list(JOIN CORE_COMPILE_DEFINITIONS " \\\n" CORE_COMPILE_DEFINITIONS)
-
-        create_carbon_docs_sphinx_target(
-            PYTHON_EXE ${Python3_EXECUTABLE}
-            VENV_NAME docs_generation_venv
-            PYTHONPATH_ENV ${PYTHONPATH_ENV_SPHINX}
-            SPHINX_SOURCE ${SPHINX_SOURCE}
-            SPHINX_BUILD ${SPHINX_BUILD}
-            DOXYGEN_SRC_FILES ${SRC_FILES}
-            SPHINX_TARGET_NAME Sphinx
-            DOXYGEN_TARGET_NAME Doxygen
-            INSTALL_DESTINATION documentation/carbon-core
-            EXTRA_COMPILE_DEFINITIONS ${CORE_COMPILE_DEFINITIONS}
-        )
-    endif()
-
     option(INSTALL_TO_MONOLITH "Install this package to a perforce branch vendor folder - provided for backwards compatability" OFF)
     if(INSTALL_TO_MONOLITH)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,29 +1,50 @@
 {
-  "dependencies": [
-    {
-      "name": "tracy",
-      "version>=": "0.13.1#1",
-      "features": [
-        "fibers",
-        "on-demand",
-        "no-callstack",
-        "manual-lifetime",
-        "delayed-init",
-        "no-crash-handler"
+  "dependencies": [],
+  "features": {
+    "docs": {
+      "description": "Generate documentation",
+      "dependencies": [
+        {
+          "name": "python3",
+          "version>=": "3.12.9#1",
+          "host": true
+        }
       ]
     },
-    {
-      "name": "gtest",
-      "version>=": "1.16.0"
+    "tests": {
+      "description": "Enable tests",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "version>=": "1.16.0"
+        }
+      ]
     },
-    {
-      "name": "lz4",
-      "version>=": "1.9.4"
+    "telemetry": {
+      "description": "Enable telemetry",
+      "dependencies": [
+        {
+          "name": "tracy",
+          "version>=": "0.13.1#1",
+          "features": [
+            "fibers",
+            "on-demand",
+            "no-callstack",
+            "manual-lifetime",
+            "delayed-init",
+            "no-crash-handler"
+          ]
+        }
+      ]
     },
-    {
-      "name": "python3",
-      "version>=": "3.12.9#1",
-      "host": true
+    "memory-tracking": {
+      "description": "Enable memory tracking",
+      "dependencies": [
+        {
+          "name": "lz4",
+          "version>=": "1.9.4"
+        }
+      ]
     }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary

Currently, vcpkg installs all dependencies. Including Python3, even if you don't build the documentation. This is mostly a problem for targets (like Emscripten), that don't allow for building Python3. But this repository doesn't actually need with its default options.

Instead, use vcpkg manifest features like some other repositories already do (like `mesh` and `resources`):
- Set the `option()`s before `project()`
- Fill in `VCPKG_MANIFEST_FEATURES`

I assumed `if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)` was a left-over guard from the migration to GitHub, and actually has no function anymore. Do let me know if that wasn't the case.

## AI assistance disclosure

<!-- Did AI tools generate or significantly assist any part of this PR (code,
tests, commit messages, this description)? If so, briefly say what and how.
Write "None" if not. Be honest: disclosure isn't held against you. What gets a
PR closed is unverified output you can't stand behind, not the use of AI. -->

Claude did a lot of triage what `if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)` was actually about. Otherwise: none

## Type of change

<!-- Tick all that apply. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup (no behaviour change)
- [ ] Documentation
- [x] Build, CI, or tooling
- [ ] Breaking change (public API or ABI)
- [ ] Other (describe below)

## Linked issue (optional)

<!-- e.g. "Closes #123" or "Refs #456". Leave blank if this PR stands on its own. -->

## What changed

<!-- Short bullets. Aim for the diff-summary you'd want as a reviewer. -->

- Order of `option()`
- vcpkg's manifest, to use features

## Testing

<!-- What did you run locally? Paste the command if it's useful. New tests added? -->

```
$ cmake --preset x64-linux-debug
-- Running vcpkg install
(..)
The following packages will be built and installed:
    gtest:x64-linux-debug@1.17.0#1 -- git+https://github.com/microsoft/vcpkg.git@9ef57e3c1c7484e79ef8dd77e9cb7770f5331248
    lz4:x64-linux-debug@1.10.0 -- git+https://github.com/microsoft/vcpkg.git@4f01eec10f515a428e914107c5188366380f8dd9
  * pthreads:x64-linux-debug@3.0.0#14 -- git+https://github.com/microsoft/vcpkg.git@2e0a6df2800d3677b941dc6504f083965b7886d9
    tracy[core,delayed-init,fibers,manual-lifetime,no-callstack,no-crash-handler,on-demand]:x64-linux-debug@0.13.1#1 -- git+https://github.com/carbonengine/vcpkg-registry.git@f358e08b7d561fd61758b4be66af4dda78cef1eb
  * vcpkg-cmake:x64-linux-debug@2024-04-23 -- git+https://github.com/microsoft/vcpkg.git@e74aa1e8f93278a8e71372f1fa08c3df420eb840
  * vcpkg-cmake-config:x64-linux-debug@2024-05-23 -- git+https://github.com/microsoft/vcpkg.git@97a63e4bc1a17422ffe4eff71da53b4b561a7841
```
(no more Python3 in default setup)

## Platforms tested

<!-- Tick what applies. Leave blank if not relevant (e.g. a Python-only or docs change). -->

- [x] Windows
- [ ] macOS
- [x] Linux

## Screenshots / captures

<!-- Only if your change has a visual effect. Drag & drop images here. -->

## Checklist

- [x] I've read [CONTRIBUTING.md](https://github.com/carbonengine/.github/blob/main/CONTRIBUTING.md).
- [x] My commits follow the commit-message style described there.
- [x] I've added or updated tests where it made sense.
- [x] I've updated docs / inline API comments for any behaviour change.
- [x] My CLA / ICLA is signed (the bot will let you know if it isn't).

---

<!--
Heads-up: builds run on our internal CI, not GitHub Actions. On all repos a
maintainer triggers the build after an initial review. Results appear as commit status checks. If you don't see activity
within a few working days, comment on the PR (the maintainers are subscribed), or
@-mention the maintainers team shown in its reviewers.
-->

###### Full disclosure: I am employed by Fenris Creations, although I have no involvement with the Carbon project. I work on this in my free time under my own name.